### PR TITLE
Update environment variable name to match config.exs

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -3,7 +3,7 @@ import Config
 config :postoffice, PostofficeWeb.Endpoint,
   secret_key_base: {:system, "SECRET_KEY_BASE", default: "12121212"}
 
-config :postoffice, pubsub_project_name: {:system, "GCLOUD_PUBSUB_PROJECT", default: "test"}
+config :postoffice, pubsub_project_name: {:system, "GCLOUD_PUBSUB_PROJECT_ID", default: "test"}
 
 config :postoffice, Postoffice.Repo,
   username: {:system, "DB_USERNAME", default: "postgres"},

--- a/lib/postoffice/adapters/pubsub.ex
+++ b/lib/postoffice/adapters/pubsub.ex
@@ -7,7 +7,7 @@ defmodule Postoffice.Adapters.Pubsub do
   @impl true
   def publish(endpoint, message) do
     Logger.info("Publishing PubSub message to #{endpoint}")
-    %{payload: payload, attributes: attributes} = message
+    %{payload: payload, attributes: _attributes} = message
     # Authenticate
     case Goth.Token.for_scope("https://www.googleapis.com/auth/cloud-platform") do
       {:ok, token} ->
@@ -16,8 +16,7 @@ defmodule Postoffice.Adapters.Pubsub do
         request = %GoogleApi.PubSub.V1.Model.PublishRequest{
           messages: [
             %GoogleApi.PubSub.V1.Model.PubsubMessage{
-              data: Base.encode64(Poison.encode!(payload)),
-              attributes: attributes
+              data: Base.encode64(Poison.encode!(payload))
             }
           ]
         }


### PR DESCRIPTION
Addresses #21 updating the environment variable name.

Gcloud pubsub attributes has been deleted until #20 is fixes as there is some type error