### PR TITLE
Fix "Web interface doesn't list disabled publishers"

### DIFF
--- a/lib/postoffice/messaging.ex
+++ b/lib/postoffice/messaging.ex
@@ -157,8 +157,14 @@ defmodule Postoffice.Messaging do
     Repo.all(query)
   end
 
-  def list_publishers do
+  def list_enabled_publishers do
     query = from(p in Publisher, where: p.active == true, preload: [:topic])
+
+    Repo.all(query)
+  end
+
+  def list_publishers do
+    query = from(p in Publisher, preload: [:topic])
 
     Repo.all(query)
   end

--- a/lib/postoffice/publisher_producer.ex
+++ b/lib/postoffice/publisher_producer.ex
@@ -31,7 +31,7 @@ defmodule Postoffice.PublisherProducer do
     Process.send_after(self(), :populate_state, @repopulate_state_interval)
 
     if :queue.len(queue) < 25 do
-      publishers = Messaging.list_publishers()
+      publishers = Messaging.list_enabled_publishers()
 
       queue =
         Enum.reduce(publishers, queue, fn publisher, acc ->

--- a/test/postoffice/messaging_test.exs
+++ b/test/postoffice/messaging_test.exs
@@ -21,6 +21,13 @@ defmodule Postoffice.MessagingTest do
       type: "http"
     }
 
+    @disabled_publisher_attrs %{
+      active: false,
+      endpoint: "http://fake.endpoint/disabled",
+      initial_message: 0,
+      type: "http"
+    }
+
     @second_publisher_attrs %{
       active: true,
       endpoint: "http://fake.endpoint2",
@@ -149,6 +156,18 @@ defmodule Postoffice.MessagingTest do
       assert publisher.endpoint == listed_publisher.endpoint
       assert publisher.active == listed_publisher.active
       assert publisher.type == listed_publisher.type
+    end
+
+    test "list_enabled_publishers/0 returns only enabled publishers" do
+      topic = topic_fixture()
+      _ = publisher_fixture(topic, @disabled_publisher_attrs)
+      enabled_publisher =  publisher_fixture(topic)
+      listed_publisher = List.first(Messaging.list_enabled_publishers())
+
+      assert enabled_publisher.id == listed_publisher.id
+      assert enabled_publisher.endpoint == listed_publisher.endpoint
+      assert enabled_publisher.active == listed_publisher.active
+      assert enabled_publisher.type == listed_publisher.type
     end
 
     test "get_message_by_uuid returns message is found" do


### PR DESCRIPTION
Just to fix #23 

- Modified 'list_publishers/0' to return enabled and disabled publishers (cb33e32)
- Added 'list_enabled_publishers/0' to return only enabled publishers (1d205d3)