### PR TITLE
Configure libcluster when required

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,9 @@ dummy_credentials_file = current_directory <> "/secrets/dummy-credentials.json"
 config :goth,
   json: System.get_env("GCLOUD_PUBSUB_CREDENTIALS_PATH", dummy_credentials_file) |> File.read!()
 
+config :libcluster,
+  topologies: []
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -78,11 +78,3 @@ config :phoenix, :stacktrace_depth, 20
 
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
-
-config :libcluster,
-  topologies: [
-    dns_poll_example: [
-      strategy: Elixir.Cluster.Strategy.DNSPoll,
-      config: [polling_interval: 5_000, query: "my-app.example.com", node_basename: "my-app"]
-    ]
-  ]

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -21,16 +21,19 @@ dummy_credentials_file = current_directory <> "/secrets/dummy-credentials.json"
 config :goth,
   json: System.get_env("GCLOUD_PUBSUB_CREDENTIALS_PATH", dummy_credentials_file) |> File.read!()
 
-config :libcluster,
-  topologies: [
-    k8s: [
-      strategy: Elixir.Cluster.Strategy.Kubernetes,
-      config: [
-        mode: :ip,
-        kubernetes_node_basename: "postoffice",
-        kubernetes_selector: "service=postoffice",
-        kubernetes_namespace: System.get_env("NAMESPACE", "staging"),
-        polling_interval: 10_000
+# If K8S_CLUSTER env_variable is set we'll try to setup a k8s cluster
+if System.get_env("K8S_CLUSTER") do
+  config :libcluster,
+    topologies: [
+      k8s: [
+        strategy: Elixir.Cluster.Strategy.Kubernetes,
+        config: [
+          mode: :ip,
+          kubernetes_node_basename: System.get_env("K8S_NODE_BASENAME"),
+          kubernetes_selector: System.get_env("K8S_SELECTOR"),
+          kubernetes_namespace: System.get_env("K8S_NAMESPACE"),
+          polling_interval: 10_000
+        ]
       ]
     ]
-  ]
+end


### PR DESCRIPTION
Do not create a cluster by default. Instead of that, read environment variables looking for `k8s` related values and create a cluster if required