### PR TITLE
Refactor adapters, moving logic to handlers

### DIFF
--- a/lib/postoffice/adapters/http.ex
+++ b/lib/postoffice/adapters/http.ex
@@ -9,18 +9,8 @@ defmodule Postoffice.Adapters.Http do
     Logger.info("Dispatching Http message to #{endpoint}")
     %{payload: payload} = message
 
-    case HTTPoison.post(endpoint, Poison.encode!(payload), [
-           {"content-type", "application/json"}
-         ]) do
-      {:ok, %HTTPoison.Response{status_code: status_code, body: _body}}
-      when status_code in 200..299 ->
-        {:ok, message}
-
-      {:ok, response} ->
-        {:error, response.status_code}
-
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        {:error, reason}
-    end
+    HTTPoison.post(endpoint, Poison.encode!(payload), [
+      {"content-type", "application/json"}
+    ])
   end
 end

--- a/lib/postoffice/adapters/pubsub.ex
+++ b/lib/postoffice/adapters/pubsub.ex
@@ -9,36 +9,24 @@ defmodule Postoffice.Adapters.Pubsub do
     Logger.info("Publishing PubSub message to #{endpoint}")
     %{payload: payload, attributes: _attributes} = message
     # Authenticate
-    case Goth.Token.for_scope("https://www.googleapis.com/auth/cloud-platform") do
-      {:ok, token} ->
-        Logger.info("successfully generated token for pubsub")
-        conn = GoogleApi.PubSub.V1.Connection.new(token.token)
+    {:ok, token} = Goth.Token.for_scope("https://www.googleapis.com/auth/cloud-platform")
+    Logger.info("successfully generated token for pubsub")
+    conn = GoogleApi.PubSub.V1.Connection.new(token.token)
 
-        request = %GoogleApi.PubSub.V1.Model.PublishRequest{
-          messages: [
-            %GoogleApi.PubSub.V1.Model.PubsubMessage{
-              data: Base.encode64(Poison.encode!(payload))
-            }
-          ]
+    request = %GoogleApi.PubSub.V1.Model.PublishRequest{
+      messages: [
+        %GoogleApi.PubSub.V1.Model.PubsubMessage{
+          data: Base.encode64(Poison.encode!(payload))
         }
+      ]
+    }
 
-        # Make the API request.
-        case GoogleApi.PubSub.V1.Api.Projects.pubsub_projects_topics_publish(
-               conn,
-               Application.get_env(:postoffice, :pubsub_project_name),
-               endpoint,
-               body: request
-             ) do
-          {:ok, _response} ->
-            {:ok, message}
-
-          {:error, info} ->
-            {:error, info}
-        end
-
-      {:error, error} ->
-        Logger.info("Could not generate token for pubsub #{error.reason}")
-        {:error, error.reason}
-    end
+    # Make the API request.
+    GoogleApi.PubSub.V1.Api.Projects.pubsub_projects_topics_publish(
+      conn,
+      Application.get_env(:postoffice, :pubsub_project_name),
+      endpoint,
+      body: request
+    )
   end
 end

--- a/lib/postoffice/handlers/pubsub.ex
+++ b/lib/postoffice/handlers/pubsub.ex
@@ -20,7 +20,7 @@ defmodule Postoffice.Handlers.Pubsub do
         {:ok, :sent}
 
       {:error, error} ->
-        Logger.info("Error trying to process message from HttpConsumer #{error}")
+        Logger.info("Error trying to process message from PubsubConsumer #{error}")
 
         Messaging.create_publisher_failure(%{
           publisher_id: publisher_id,

--- a/test/postoffice/handlers/http_test.exs
+++ b/test/postoffice/handlers/http_test.exs
@@ -38,7 +38,7 @@ defmodule Postoffice.Handlers.HttpTest do
     {:ok, message} = Messaging.create_message(topic, @valid_message_attrs)
 
     expect(HttpMock, :publish, fn "http://fake.endpoint", ^message ->
-      {:error, 404}
+      {:ok, %HTTPoison.Response{status_code: 404}}
     end)
 
     Http.run(publisher.endpoint, publisher.id, message)
@@ -56,7 +56,7 @@ defmodule Postoffice.Handlers.HttpTest do
     {:ok, message} = Messaging.create_message(topic, @valid_message_attrs)
 
     expect(HttpMock, :publish, fn "http://fake.endpoint", ^message ->
-      {:ok, message}
+      {:ok, %HTTPoison.Response{status_code: 201}}
     end)
 
     Http.run(publisher.endpoint, publisher.id, message)
@@ -72,7 +72,7 @@ defmodule Postoffice.Handlers.HttpTest do
     {:ok, message} = Messaging.create_message(topic, @valid_message_attrs)
 
     expect(HttpMock, :publish, fn "http://fake.endpoint", ^message ->
-      {:error, %HTTPoison.Error{reason: "test"}}
+      {:error, %HTTPoison.Error{reason: "test error reason"}}
     end)
 
     Http.run(publisher.endpoint, publisher.id, message)
@@ -80,7 +80,7 @@ defmodule Postoffice.Handlers.HttpTest do
     assert message_failure.message_id == message.id
   end
 
-  test "message_failure is created for publisher if response is :ok but response_code != 200" do
+  test "message_failure is created for publisher if response is :ok but response_code out of 200 range" do
     {:ok, topic} = Messaging.create_topic(@valid_topic_attrs)
 
     {:ok, publisher} =
@@ -89,7 +89,7 @@ defmodule Postoffice.Handlers.HttpTest do
     {:ok, message} = Messaging.create_message(topic, @valid_message_attrs)
 
     expect(HttpMock, :publish, fn "http://fake.endpoint", ^message ->
-      {:error, %HTTPoison.Response{status_code: 201}}
+      {:ok, %HTTPoison.Response{status_code: 300}}
     end)
 
     Http.run(publisher.endpoint, publisher.id, message)


### PR DESCRIPTION
Adapters layers exists for two reasons: 
* Is just a proxy layer for external dependencies.
* Help on testing

All logic is now on Handlers