### PR TITLE
Fix pubsub publish

### DIFF
--- a/lib/postoffice/handlers/http.ex
+++ b/lib/postoffice/handlers/http.ex
@@ -7,7 +7,8 @@ defmodule Postoffice.Handlers.Http do
 
   def run(publisher_endpoint, publisher_id, message) do
     case impl().publish(publisher_endpoint, message) do
-      {:ok, %HTTPoison.Response{status_code: status_code, body: _body}} when status_code in 200..299 ->
+      {:ok, %HTTPoison.Response{status_code: status_code, body: _body}}
+      when status_code in 200..299 ->
         Logger.info("Succesfully sent http message to #{publisher_endpoint}")
 
         {:ok, _} =
@@ -37,7 +38,6 @@ defmodule Postoffice.Handlers.Http do
         })
 
         {:error, :nosent}
-
     end
   end
 

--- a/lib/postoffice/handlers/pubsub.ex
+++ b/lib/postoffice/handlers/pubsub.ex
@@ -3,12 +3,13 @@ defmodule Postoffice.Handlers.Pubsub do
 
   require Logger
 
+  alias GoogleApi.PubSub.V1.Model.PublishResponse
   alias Postoffice.Messaging
-  alias Postoffice.Messaging.Message
 
+  @spec run(any, any, any) :: {:error, :nosent} | {:ok, :sent}
   def run(publisher_endpoint, publisher_id, message) do
     case impl().publish(publisher_endpoint, message) do
-      {:ok, message = %Message{}} ->
+      {:ok, _response = %PublishResponse{}} ->
         Logger.info("Succesfully sent pubsub message to #{publisher_endpoint}")
 
         {:ok, _} =

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,12 @@ defmodule Postoffice.MixProject do
         ]
       ],
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test]
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ]
     ]
   end
 

--- a/test/postoffice/handlers/pubsub_test.exs
+++ b/test/postoffice/handlers/pubsub_test.exs
@@ -3,10 +3,12 @@ defmodule Postoffice.Handlers.PubsubTest do
 
   import Mox
 
+  alias GoogleApi.PubSub.V1.Model.PublishResponse
   alias Postoffice.Adapters.PubsubMock
   alias Postoffice.Handlers.Pubsub
   alias Postoffice.Messaging
   alias Postoffice.Messaging.Message
+
 
   @valid_message_attrs %{
     attributes: %{},
@@ -59,7 +61,7 @@ defmodule Postoffice.Handlers.PubsubTest do
     {:ok, message} = Messaging.create_message(topic, @valid_message_attrs)
 
     expect(PubsubMock, :publish, fn "test-publisher", ^message ->
-      {:ok, message}
+      {:ok, %PublishResponse{}}
     end)
 
     Pubsub.run(publisher.endpoint, publisher.id, message)

--- a/test/postoffice/handlers/pubsub_test.exs
+++ b/test/postoffice/handlers/pubsub_test.exs
@@ -9,7 +9,6 @@ defmodule Postoffice.Handlers.PubsubTest do
   alias Postoffice.Messaging
   alias Postoffice.Messaging.Message
 
-
   @valid_message_attrs %{
     attributes: %{},
     payload: %{},

--- a/test/postoffice/messaging_test.exs
+++ b/test/postoffice/messaging_test.exs
@@ -275,6 +275,5 @@ defmodule Postoffice.MessagingTest do
 
       assert Messaging.count_publishers_failures() == 1
     end
-
   end
 end


### PR DESCRIPTION
Pubsub library returns {:ok, PublishResponse} when the message is succesfuly sent, not {:ok, message} as preivously. 