### PR TITLE
Add metrics endpoint for prometheus

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,8 @@ config :postoffice, PostofficeWeb.Endpoint,
   secret_key_base: "ltXgZliDmN0mLNWAF5iobiRF6G3q96oWvttpWlqb1hahcxgAwcxOGG9R5khNiWy5",
   render_errors: [view: PostofficeWeb.ErrorView, accepts: ~w(json)],
   pubsub: [name: Postoffice.PubSub, adapter: Phoenix.PubSub.PG2],
-  root: "."
+  root: ".",
+  instrumenters: [PostofficeWeb.Metrics.Phoenix]
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/lib/postoffice/application.ex
+++ b/lib/postoffice/application.ex
@@ -7,6 +7,7 @@ defmodule Postoffice.Application do
 
   def start(_type, _args) do
     # List all child processes to be supervised
+    Postoffice.MetricsSetup.setup()
     children = [
       # Start the Ecto repository
       Postoffice.Repo,
@@ -24,6 +25,7 @@ defmodule Postoffice.Application do
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Postoffice.Supervisor]
     Supervisor.start_link(children, opts)
+
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/lib/postoffice/metrics_setup.ex
+++ b/lib/postoffice/metrics_setup.ex
@@ -1,0 +1,6 @@
+defmodule Postoffice.MetricsSetup do
+  def setup do
+    PostofficeWeb.Metrics.Phoenix.setup()
+    PostofficeWeb.Metrics.Exporter.setup()
+  end
+end

--- a/lib/postoffice_web/endpoint.ex
+++ b/lib/postoffice_web/endpoint.ex
@@ -32,10 +32,11 @@ defmodule PostofficeWeb.Endpoint do
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
   plug Plug.Session,
-    store: :cookie,
-    key: "_my_app_key",
-    signing_salt: "To8iCTxd"
+  store: :cookie,
+  key: "_my_app_key",
+  signing_salt: "To8iCTxd"
 
   PostofficeWeb
+  plug PostofficeWeb.Metrics.Exporter
   plug PostofficeWeb.Router
 end

--- a/lib/postoffice_web/metrics/exporter.ex
+++ b/lib/postoffice_web/metrics/exporter.ex
@@ -1,0 +1,3 @@
+defmodule PostofficeWeb.Metrics.Exporter do
+  use Prometheus.PlugExporter
+end

--- a/lib/postoffice_web/metrics/phoenix.ex
+++ b/lib/postoffice_web/metrics/phoenix.ex
@@ -1,0 +1,3 @@
+defmodule PostofficeWeb.Metrics.Phoenix do
+  use Prometheus.PhoenixInstrumenter
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Postoffice.MixProject do
   def application do
     [
       mod: {Postoffice.Application, []},
-      extra_applications: [:logger, :runtime_tools, :httpoison, :logger_json]
+      extra_applications: [:logger, :runtime_tools, :httpoison, :logger_json, :prometheus_phoenix]
     ]
   end
 
@@ -66,7 +66,10 @@ defmodule Postoffice.MixProject do
       {:config_tuples, "~> 0.4"},
       {:libcluster, "~> 3.1"},
       {:swarm, "~> 3.0"},
-      {:excoveralls, "~> 0.4"}
+      {:excoveralls, "~> 0.4"},
+      {:prometheus_ex, "~> 3.0"},
+      {:prometheus_plugs, "~> 1.1"},
+      {:prometheus_phoenix, "~> 1.3.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "accept": {:hex, :accept, "0.3.5", "b33b127abca7cc948bbe6caa4c263369abf1347cfa9d8e699c6d214660f10cd1", [:rebar3], [], "hexpm"},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], [], "hexpm"},
   "bcrypt_elixir": {:hex, :bcrypt_elixir, "2.0.3", "64e0792d5b5064391927bf3b8e436994cafd18ca2d2b76dea5c76e0adcf66b7c", [:make, :mix], [{:comeonin, "~> 5.1", [hex: :comeonin, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
@@ -44,6 +45,11 @@
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.15.3", "5806baa8a19a68c4d07c7a624ccdb9b57e89cbc573f1b98099e3741214746ae4", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
+  "prometheus": {:hex, :prometheus, "4.5.0", "8f4a2246fe0beb50af0f77c5e0a5bb78fe575c34a9655d7f8bc743aad1c6bf76", [:mix, :rebar3], [], "hexpm"},
+  "prometheus_ecto": {:hex, :prometheus_ecto, "1.4.3", "3dd4da1812b8e0dbee81ea58bb3b62ed7588f2eae0c9e97e434c46807ff82311", [:mix], [{:ecto, "~> 2.0 or ~> 3.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:prometheus_ex, "~> 1.1 or ~> 2.0 or ~> 3.0", [hex: :prometheus_ex, repo: "hexpm", optional: false]}], "hexpm"},
+  "prometheus_ex": {:hex, :prometheus_ex, "3.0.5", "fa58cfd983487fc5ead331e9a3e0aa622c67232b3ec71710ced122c4c453a02f", [:mix], [{:prometheus, "~> 4.0", [hex: :prometheus, repo: "hexpm", optional: false]}], "hexpm"},
+  "prometheus_phoenix": {:hex, :prometheus_phoenix, "1.3.0", "c4b527e0b3a9ef1af26bdcfbfad3998f37795b9185d475ca610fe4388fdd3bb5", [:mix], [{:phoenix, "~> 1.4", [hex: :phoenix, repo: "hexpm", optional: false]}, {:prometheus_ex, "~> 1.3 or ~> 2.0 or ~> 3.0", [hex: :prometheus_ex, repo: "hexpm", optional: false]}], "hexpm"},
+  "prometheus_plugs": {:hex, :prometheus_plugs, "1.1.5", "25933d48f8af3a5941dd7b621c889749894d8a1082a6ff7c67cc99dec26377c5", [:mix], [{:accept, "~> 0.1", [hex: :accept, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}, {:prometheus_ex, "~> 1.1 or ~> 2.0 or ~> 3.0", [hex: :prometheus_ex, repo: "hexpm", optional: false]}, {:prometheus_process_collector, "~> 1.1", [hex: :prometheus_process_collector, repo: "hexpm", optional: true]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
   "swarm": {:hex, :swarm, "3.4.0", "64f8b30055d74640d2186c66354b33b999438692a91be275bb89cdc7e401f448", [:mix], [{:gen_state_machine, "~> 2.0", [hex: :gen_state_machine, repo: "hexpm", optional: false]}, {:libring, "~> 1.0", [hex: :libring, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
To monitor application and virtual machine performance, we've added `/metrics` endpoint to be called from Prometheus