### PR TITLE
Do symmetry between publishers and topic

### DIFF
--- a/lib/postoffice.ex
+++ b/lib/postoffice.ex
@@ -23,14 +23,8 @@ defmodule Postoffice do
     end
   end
 
-  def create_topic(%{"name" => topic_name} = topic_params) do
-    case Messaging.get_topic(topic_name) do
-      nil ->
-        Messaging.create_topic(topic_params)
-
-      topic ->
-        {:ok, topic}
-    end
+  def create_topic(topic_params) do
+    Messaging.create_topic(topic_params)
   end
 
   def receive_publisher(%{"topic" => topic} = publisher_params) do

--- a/lib/postoffice/handlers/http.ex
+++ b/lib/postoffice/handlers/http.ex
@@ -3,7 +3,6 @@ defmodule Postoffice.Handlers.Http do
   require Logger
 
   alias Postoffice.Messaging
-  alias Postoffice.Messaging.Message
 
   def run(publisher_endpoint, publisher_id, message) do
     case impl().publish(publisher_endpoint, message) do

--- a/lib/postoffice_web/controllers/api/topic_controller.ex
+++ b/lib/postoffice_web/controllers/api/topic_controller.ex
@@ -3,19 +3,13 @@ defmodule PostofficeWeb.Api.TopicController do
 
   alias Postoffice.Messaging.Topic
 
-  action_fallback PostofficeWeb.FallbackController
+  action_fallback PostofficeWeb.Api.FallbackController
 
   def create(conn, topic_params) do
-    case Postoffice.create_topic(topic_params) do
-      {:ok, topic} ->
-        conn
-        |> put_status(:created)
-        |> render("show.json", topic: topic)
-
-      {:error, changeset} ->
-        conn
-        |> put_status(:bad_request)
-        |> render("show.json", changeset: changeset)
+    with {:ok, %Topic{} = topic} <- Postoffice.create_topic(topic_params) do
+      conn
+      |> put_status(:created)
+      |> render("show.json", topic: topic)
     end
   end
 end

--- a/lib/postoffice_web/controllers/api/topic_controller.ex
+++ b/lib/postoffice_web/controllers/api/topic_controller.ex
@@ -6,17 +6,13 @@ defmodule PostofficeWeb.Api.TopicController do
   action_fallback PostofficeWeb.FallbackController
 
   def create(conn, topic_params) do
-    changeset = Topic.changeset(%Topic{}, topic_params)
-
-    case changeset.valid? do
-      true ->
-        {:ok, topic} = Postoffice.create_topic(topic_params)
-
+    case Postoffice.create_topic(topic_params) do
+      {:ok, topic} ->
         conn
         |> put_status(:created)
         |> render("show.json", topic: topic)
 
-      false ->
+      {:error, changeset} ->
         conn
         |> put_status(:bad_request)
         |> render("show.json", changeset: changeset)

--- a/lib/postoffice_web/views/api/topic_view.ex
+++ b/lib/postoffice_web/views/api/topic_view.ex
@@ -17,9 +17,7 @@ defmodule PostofficeWeb.Api.TopicView do
     }
   end
 
-  def render("error.json", %{topic: topic_changeset}) do
-    %{
-      errors: Ecto.Changeset.traverse_errors(topic_changeset, &translate_error/1)
-    }
+  def render("error.json", %{changeset: changeset}) do
+    %{data: %{errors: Ecto.Changeset.traverse_errors(changeset, &translate_error/1)}}
   end
 end

--- a/lib/postoffice_web/views/api/topic_view.ex
+++ b/lib/postoffice_web/views/api/topic_view.ex
@@ -6,10 +6,6 @@ defmodule PostofficeWeb.Api.TopicView do
     %{data: render_one(topic, TopicView, "topic.json")}
   end
 
-  def render("show.json", %{changeset: changeset}) do
-    %{data: render_one(changeset, TopicView, "error.json")}
-  end
-
   def render("topic.json", %{topic: topic}) do
     %{
       id: topic.id,

--- a/test/postoffice/messaging_test.exs
+++ b/test/postoffice/messaging_test.exs
@@ -3,7 +3,7 @@ defmodule Postoffice.MessagingTest do
 
   alias Postoffice.Messaging
   alias Postoffice.Messaging.Message
-  alias Postoffice.Fixtures, as: Fixtures
+  alias Postoffice.Fixtures
 
   @second_topic_attrs %{
     name: "test2"

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -22,8 +22,8 @@ defmodule Postoffice.PostofficeTest do
     end
 
     test "count_messages returns number of created messages" do
-      topic = Fixtures.topic_fixture()
-      Fixtures.message_fixture(topic)
+      topic = Fixtures.create_topic()
+      Fixtures.create_message(topic)
 
       assert Postoffice.count_received_messages() == 1
     end
@@ -33,10 +33,10 @@ defmodule Postoffice.PostofficeTest do
     end
 
     test "count_published_messages returns number of published messages" do
-      topic = Fixtures.topic_fixture()
-      publisher = Fixtures.publisher_fixture(topic)
-      message = Fixtures.message_fixture(topic)
-      Fixtures.publisher_success_fixture(message, publisher)
+      topic = Fixtures.create_topic()
+      publisher = Fixtures.create_publisher(topic)
+      message = Fixtures.create_message(topic)
+      Fixtures.create_publisher_success(message, publisher)
 
       assert Postoffice.count_published_messages() == 1
     end
@@ -46,10 +46,10 @@ defmodule Postoffice.PostofficeTest do
     end
 
     test "count_publishers_failures returns number of failed messages" do
-      topic = Fixtures.topic_fixture()
-      publisher = Fixtures.publisher_fixture(topic)
-      message = Fixtures.message_fixture(topic)
-      Fixtures.publishers_failure_fixture(message, publisher)
+      topic = Fixtures.create_topic()
+      publisher = Fixtures.create_publisher(topic)
+      message = Fixtures.create_message(topic)
+      Fixtures.create_publishers_failure(message, publisher)
 
       assert Postoffice.count_publishers_failures() == 1
     end
@@ -59,9 +59,9 @@ defmodule Postoffice.PostofficeTest do
     end
 
     test "count_publishers returns number of created publishers" do
-      topic = Fixtures.topic_fixture()
-      Fixtures.publisher_fixture(topic)
-      Fixtures.publisher_fixture(topic, @publisher_attrs)
+      topic = Fixtures.create_topic()
+      Fixtures.create_publisher(topic)
+      Fixtures.create_publisher(topic, @publisher_attrs)
 
       assert Postoffice.count_publishers() == 2
     end
@@ -71,7 +71,7 @@ defmodule Postoffice.PostofficeTest do
     end
 
     test "count_topics returns number of created topics" do
-      Fixtures.topic_fixture()
+      Fixtures.create_topic()
 
       assert Postoffice.count_topics() == 1
     end

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -5,6 +5,13 @@ defmodule Postoffice.PostofficeTest do
   alias Postoffice.Messaging
   alias Postoffice.Fixtures, as: Fixtures
 
+  @publisher_attrs %{
+    active: true,
+    endpoint: "http://fake.endpoint2",
+    initial_message: 0,
+    type: "http"
+  }
+
   describe "PostofficeWeb external api" do
     test "Returns nil if tried to find message by invalid UUID" do
       assert Postoffice.find_message_by_uuid(123) == nil
@@ -45,6 +52,18 @@ defmodule Postoffice.PostofficeTest do
       Fixtures.publishers_failure_fixture(message, publisher)
 
       assert Postoffice.count_publishers_failures() == 1
+    end
+
+    test "count_publishers returns 0 if no publisher exists" do
+      assert Postoffice.count_publishers() == 0
+    end
+
+    test "count_publishers returns number of created publishers" do
+      topic = Fixtures.topic_fixture()
+      Fixtures.publisher_fixture(topic)
+      Fixtures.publisher_fixture(topic, @publisher_attrs)
+
+      assert Postoffice.count_publishers() == 2
     end
   end
 end

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -2,7 +2,7 @@ defmodule Postoffice.PostofficeTest do
   use Postoffice.DataCase
 
   alias Postoffice
-  alias Postoffice.Fixtures, as: Fixtures
+  alias Postoffice.Fixtures
 
   @publisher_attrs %{
     active: true,

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -3,27 +3,7 @@ defmodule Postoffice.PostofficeTest do
 
   alias Postoffice
   alias Postoffice.Messaging
-
-  @topic_attrs %{
-    name: "test"
-  }
-
-  @message_attrs %{
-    attributes: %{},
-    payload: %{},
-    public_id: "7488a646-e31f-11e4-aace-600308960662"
-  }
-
-  def message_fixture(topic, attrs \\ @message_attrs) do
-    {:ok, message} = Messaging.create_message(topic, attrs)
-
-    message
-  end
-
-  def topic_fixture(attrs \\ @topic_attrs) do
-    {:ok, topic} = Messaging.create_topic(attrs)
-    topic
-  end
+  alias Postoffice.Fixtures, as: Fixtures
 
   describe "PostofficeWeb external api" do
     test "Returns nil if tried to find message by invalid UUID" do
@@ -35,10 +15,23 @@ defmodule Postoffice.PostofficeTest do
     end
 
     test "count_messages returns number of created messages" do
-      topic = topic_fixture()
-      message_fixture(topic)
+      topic = Fixtures.topic_fixture()
+      Fixtures.message_fixture(topic)
 
       assert Postoffice.count_received_messages() == 1
+    end
+
+    test "count_published_messages returns 0 if no published message exists" do
+      assert Postoffice.count_published_messages() == 0
+    end
+
+    test "count_published_messages returns number of published messages" do
+      topic = Fixtures.topic_fixture()
+      publisher = Fixtures.publisher_fixture(topic)
+      message = Fixtures.message_fixture(topic)
+      Fixtures.publisher_success_fixture(message, publisher)
+
+      assert Messaging.count_published_messages() == 1
     end
   end
 end

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -65,5 +65,15 @@ defmodule Postoffice.PostofficeTest do
 
       assert Postoffice.count_publishers() == 2
     end
+
+    test "count_topics returns 0 if no topic exists" do
+      assert Postoffice.count_topics() == 0
+    end
+
+    test "count_topics returns number of created topics" do
+      Fixtures.topic_fixture()
+
+      assert Postoffice.count_topics() == 1
+    end
   end
 end

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -31,7 +31,20 @@ defmodule Postoffice.PostofficeTest do
       message = Fixtures.message_fixture(topic)
       Fixtures.publisher_success_fixture(message, publisher)
 
-      assert Messaging.count_published_messages() == 1
+      assert Postoffice.count_published_messages() == 1
+    end
+
+    test "count_publishers_failures returns 0 if no failed message exists" do
+      assert Postoffice.count_publishers_failures() == 0
+    end
+
+    test "count_publishers_failures returns number of failed messages" do
+      topic = Fixtures.topic_fixture()
+      publisher = Fixtures.publisher_fixture(topic)
+      message = Fixtures.message_fixture(topic)
+      Fixtures.publishers_failure_fixture(message, publisher)
+
+      assert Postoffice.count_publishers_failures() == 1
     end
   end
 end

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -2,7 +2,6 @@ defmodule Postoffice.PostofficeTest do
   use Postoffice.DataCase
 
   alias Postoffice
-  alias Postoffice.Messaging
   alias Postoffice.Fixtures, as: Fixtures
 
   @publisher_attrs %{

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -2,10 +2,43 @@ defmodule Postoffice.PostofficeTest do
   use Postoffice.DataCase
 
   alias Postoffice
+  alias Postoffice.Messaging
+
+  @topic_attrs %{
+    name: "test"
+  }
+
+  @message_attrs %{
+    attributes: %{},
+    payload: %{},
+    public_id: "7488a646-e31f-11e4-aace-600308960662"
+  }
+
+  def message_fixture(topic, attrs \\ @message_attrs) do
+    {:ok, message} = Messaging.create_message(topic, attrs)
+
+    message
+  end
+
+  def topic_fixture(attrs \\ @topic_attrs) do
+    {:ok, topic} = Messaging.create_topic(attrs)
+    topic
+  end
 
   describe "PostofficeWeb external api" do
     test "Returns nil if tried to find message by invalid UUID" do
       assert Postoffice.find_message_by_uuid(123) == nil
+    end
+
+    test "count_received_messages returns 0 if no message exists" do
+      assert Postoffice.count_received_messages() == 0
+    end
+
+    test "count_messages returns number of created messages" do
+      topic = topic_fixture()
+      message_fixture(topic)
+
+      assert Postoffice.count_received_messages() == 1
     end
   end
 end

--- a/test/postoffice_web/controllers/api/topic_controller_test.exs
+++ b/test/postoffice_web/controllers/api/topic_controller_test.exs
@@ -8,7 +8,7 @@ defmodule PostofficeWeb.Api.TopicControllerTest do
   @create_attrs %{
     name: "test"
   }
-  @invalid_attrs %{invalid_key: "invalid"}
+  @invalid_attrs %{name: ""}
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
@@ -27,13 +27,13 @@ defmodule PostofficeWeb.Api.TopicControllerTest do
     end
 
     test "do not create topic in case it already exists", %{conn: conn} do
-      {:ok, existing_topic} = Messaging.create_topic(%{name: "test"})
+      {:ok, existing_topic} = Messaging.create_topic(@create_attrs)
 
       conn = post(conn, Routes.api_topic_path(conn, :create), @create_attrs)
 
       assert json_response(conn, 400)["data"] == %{
-        "errors" => %{"name" => ["has already been taken"]}
-      }
+               "errors" => %{"name" => ["has already been taken"]}
+             }
 
       assert length(Repo.all(Topic)) == 1
     end

--- a/test/postoffice_web/controllers/api/topic_controller_test.exs
+++ b/test/postoffice_web/controllers/api/topic_controller_test.exs
@@ -2,6 +2,8 @@ defmodule PostofficeWeb.Api.TopicControllerTest do
   use PostofficeWeb.ConnCase
 
   alias Postoffice.Messaging
+  alias Postoffice.Messaging.Topic
+  alias Postoffice.Repo
 
   @create_attrs %{
     name: "test"
@@ -26,9 +28,14 @@ defmodule PostofficeWeb.Api.TopicControllerTest do
 
     test "do not create topic in case it already exists", %{conn: conn} do
       {:ok, existing_topic} = Messaging.create_topic(%{name: "test"})
+
       conn = post(conn, Routes.api_topic_path(conn, :create), @create_attrs)
-      new_topic = json_response(conn, 201)["data"]
-      assert new_topic["id"] == existing_topic.id
+
+      assert json_response(conn, 400)["data"] == %{
+        "errors" => %{"name" => ["has already been taken"]}
+      }
+
+      assert length(Repo.all(Topic)) == 1
     end
   end
 end

--- a/test/postoffice_web/controllers/api/topic_controller_test.exs
+++ b/test/postoffice_web/controllers/api/topic_controller_test.exs
@@ -27,7 +27,7 @@ defmodule PostofficeWeb.Api.TopicControllerTest do
     end
 
     test "do not create topic in case it already exists", %{conn: conn} do
-      {:ok, existing_topic} = Messaging.create_topic(@create_attrs)
+      {:ok, _topic} = Messaging.create_topic(@create_attrs)
 
       conn = post(conn, Routes.api_topic_path(conn, :create), @create_attrs)
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -22,28 +22,28 @@ defmodule Postoffice.Fixtures do
     type: "http"
   }
 
-  def message_fixture(topic, attrs \\ @message_attrs) do
+  def create_message(topic, attrs \\ @message_attrs) do
     {:ok, message} = Messaging.create_message(topic, attrs)
 
     message
   end
 
-  def topic_fixture(attrs \\ @topic_attrs) do
+  def create_topic(attrs \\ @topic_attrs) do
     {:ok, topic} = Messaging.create_topic(attrs)
     topic
   end
 
-  def publisher_fixture(topic, attrs \\ @publisher_attrs) do
+  def create_publisher(topic, attrs \\ @publisher_attrs) do
     {:ok, publisher} = Messaging.create_publisher(Map.put(attrs, :topic_id, topic.id))
     publisher
   end
 
-  def publisher_success_fixture(message, publisher) do
+  def create_publisher_success(message, publisher) do
     {:ok, _publisher_success} =
       Messaging.create_publisher_success(%{message_id: message.id, publisher_id: publisher.id})
   end
 
-  def publishers_failure_fixture(message, publisher) do
+  def create_publishers_failure(message, publisher) do
     {:ok, _publisher_success} =
       Messaging.create_publisher_failure(%{message_id: message.id, publisher_id: publisher.id})
   end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -4,7 +4,6 @@ defmodule Postoffice.Fixtures do
   """
   alias Postoffice
   alias Postoffice.Messaging
-  alias Postoffice.Fixtures
 
   @topic_attrs %{
     name: "test"
@@ -42,5 +41,10 @@ defmodule Postoffice.Fixtures do
   def publisher_success_fixture(message, publisher) do
     {:ok, _publisher_success} =
       Messaging.create_publisher_success(%{message_id: message.id, publisher_id: publisher.id})
+  end
+
+  def publishers_failure_fixture(message, publisher) do
+    {:ok, _publisher_success} =
+      Messaging.create_publisher_failure(%{message_id: message.id, publisher_id: publisher.id})
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,0 +1,46 @@
+defmodule Postoffice.Fixtures do
+  @moduledoc """
+  This module defines the shared fixtures between the tests
+  """
+  alias Postoffice
+  alias Postoffice.Messaging
+  alias Postoffice.Fixtures
+
+  @topic_attrs %{
+    name: "test"
+  }
+
+  @message_attrs %{
+    attributes: %{},
+    payload: %{},
+    public_id: "7488a646-e31f-11e4-aace-600308960662"
+  }
+
+  @publisher_attrs %{
+    active: true,
+    endpoint: "http://fake.endpoint",
+    initial_message: 0,
+    type: "http"
+  }
+
+  def message_fixture(topic, attrs \\ @message_attrs) do
+    {:ok, message} = Messaging.create_message(topic, attrs)
+
+    message
+  end
+
+  def topic_fixture(attrs \\ @topic_attrs) do
+    {:ok, topic} = Messaging.create_topic(attrs)
+    topic
+  end
+
+  def publisher_fixture(topic, attrs \\ @publisher_attrs) do
+    {:ok, publisher} = Messaging.create_publisher(Map.put(attrs, :topic_id, topic.id))
+    publisher
+  end
+
+  def publisher_success_fixture(message, publisher) do
+    {:ok, _publisher_success} =
+      Messaging.create_publisher_success(%{message_id: message.id, publisher_id: publisher.id})
+  end
+end


### PR DESCRIPTION
- Returns 400 when create topic that already exists
- Use callback to manage errors on topic api 
- Add some missing tests in the project

https://github.com/lonamiaec/postoffice/issues/15