### PR TITLE
Prepare for v0.4.1 version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Postoffice.MixProject do
   def project do
     [
       app: :postoffice,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
It includes a fix related with `limit` in a query, it was taking down the service when messages > 100k