### PR TITLE
Add topic's message recovery field

### DIFF
--- a/lib/postoffice/messaging.ex
+++ b/lib/postoffice/messaging.ex
@@ -205,8 +205,8 @@ defmodule Postoffice.Messaging do
     |> Repo.all()
   end
 
-  def get_topic_origin_hosts() do
-    from(t in Topic, distinct: true, select: t.origin_host)
+  def get_recovery_hosts() do
+    from(t in Topic, where: t.recovery_enabled == true, distinct: true, select: t.origin_host)
     |> Repo.all()
   end
 end

--- a/lib/postoffice/messaging/topic.ex
+++ b/lib/postoffice/messaging/topic.ex
@@ -5,6 +5,7 @@ defmodule Postoffice.Messaging.Topic do
   schema "topics" do
     field :name, :string, null: false
     field :origin_host, :string, null: true
+    field :recovery_enabled, :boolean, null: false, default: false
 
     has_many :consumers, Postoffice.Messaging.Publisher
     has_many :messages, Postoffice.Messaging.Message
@@ -15,7 +16,7 @@ defmodule Postoffice.Messaging.Topic do
   @doc false
   def changeset(message, attrs) do
     message
-    |> cast(attrs, [:name, :origin_host])
+    |> cast(attrs, [:name, :origin_host, :recovery_enabled])
     |> validate_required([:name, :origin_host])
     |> unique_constraint(:name)
   end

--- a/lib/postoffice/rescuer/producer.ex
+++ b/lib/postoffice/rescuer/producer.ex
@@ -31,7 +31,7 @@ defmodule Postoffice.Rescuer.Producer do
   def handle_info(:populate_state, {queue, pending_demand} = state) do
     Process.send_after(self(), :populate_state, @rescuer_interval)
 
-    hosts = Messaging.get_topic_origin_hosts()
+    hosts = Messaging.get_recovery_hosts()
 
     queue =
       Enum.reduce(hosts, queue, fn host, acc ->

--- a/priv/repo/migrations/20200312102526_add_recovery_enabled_to_topic.exs
+++ b/priv/repo/migrations/20200312102526_add_recovery_enabled_to_topic.exs
@@ -1,0 +1,9 @@
+defmodule Postoffice.Repo.Migrations.AddRecoveryEnabledToTopic do
+  use Ecto.Migration
+
+  def change do
+    alter table(:topics) do
+      add :recovery_enabled, :boolean, default: false
+    end
+  end
+end

--- a/test/postoffice/messaging_test.exs
+++ b/test/postoffice/messaging_test.exs
@@ -8,7 +8,7 @@ defmodule Postoffice.MessagingTest do
   @second_topic_attrs %{
     name: "test2",
     origin_host: "example2.com",
-    recovery_enabled: true
+    recovery_enabled: false
   }
 
   @disabled_publisher_attrs %{
@@ -82,14 +82,14 @@ defmodule Postoffice.MessagingTest do
     end
 
     test "create_topic/1 with recovery_enabled" do
-      {:ok, topic} = Messaging.create_topic(@second_topic_attrs)
+      topic_params = %{@second_topic_attrs | recovery_enabled: true}
+      {:ok, topic} = Messaging.create_topic(topic_params)
 
-      assert topic.recovery_enabled
+      assert topic.recovery_enabled == true
     end
 
     test "create_topic/1 with disabled recovery_enabled" do
-      topic_params = %{@second_topic_attrs | recovery_enabled: false}
-      {:ok, topic} = Messaging.create_topic(topic_params)
+      {:ok, topic} = Messaging.create_topic(@second_topic_attrs)
 
       assert topic.recovery_enabled == false
     end
@@ -305,7 +305,7 @@ defmodule Postoffice.MessagingTest do
       assert Kernel.length(loaded_publisher_failures) == 1
     end
 
-    test "get_topic_origin_hosts returns unique hosts" do
+    test "get_recovery_hosts returns unique hosts" do
       _topic = Fixtures.create_topic()
 
       _second_topic =
@@ -314,9 +314,17 @@ defmodule Postoffice.MessagingTest do
           origin_host: "example.com"
         })
 
-      hosts = Messaging.get_topic_origin_hosts()
+      hosts = Messaging.get_recovery_hosts()
 
       assert Kernel.length(hosts) == 1
+    end
+
+    test "get_recovery_hosts returns empty list if no topic has recovery enabled" do
+      Messaging.create_topic(@second_topic_attrs)
+
+      hosts = Messaging.get_recovery_hosts()
+
+      assert hosts == []
     end
   end
 end

--- a/test/postoffice/messaging_test.exs
+++ b/test/postoffice/messaging_test.exs
@@ -7,7 +7,8 @@ defmodule Postoffice.MessagingTest do
 
   @second_topic_attrs %{
     name: "test2",
-    origin_host: "example2.com"
+    origin_host: "example2.com",
+    recovery_enabled: true
   }
 
   @disabled_publisher_attrs %{
@@ -78,6 +79,19 @@ defmodule Postoffice.MessagingTest do
     test "create_message/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} =
                Messaging.create_message(Fixtures.create_topic(), @invalid_message_attrs)
+    end
+
+    test "create_topic/1 with recovery_enabled" do
+      {:ok, topic} = Messaging.create_topic(@second_topic_attrs)
+
+      assert topic.recovery_enabled
+    end
+
+    test "create_topic/1 with disabled recovery_enabled" do
+      topic_params = %{@second_topic_attrs | recovery_enabled: false}
+      {:ok, topic} = Messaging.create_topic(topic_params)
+
+      assert topic.recovery_enabled == false
     end
 
     test "list_topics/0 returns all topics" do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -7,7 +7,8 @@ defmodule Postoffice.Fixtures do
 
   @topic_attrs %{
     name: "test",
-    origin_host: "example.com"
+    origin_host: "example.com",
+    recovery_enabled: true
   }
 
   @message_attrs %{


### PR DESCRIPTION
With this field we'll know if we should start the recovery process for a given topic or not (it depends on the sender system, if it implements the required API or not)