### PR TITLE
Use estimated counts to improve dashboard performance

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,7 +11,6 @@ config :postoffice, Postoffice.Repo,
   pool_size: 20,
   queue_target: 3000
 
-
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #

--- a/lib/postoffice.ex
+++ b/lib/postoffice.ex
@@ -82,9 +82,9 @@ defmodule Postoffice do
 
   def get_last_messages(limit \\ 10), do: Messaging.list_messages(limit)
 
-  def count_received_messages, do: Messaging.count_messages()
+  def estimated_messages_count, do: Messaging.get_estimated_count("messages")
 
-  def count_published_messages, do: Messaging.count_published_messages()
+  def estimated_published_messages_count, do: Messaging.get_estimated_count("publisher_success")
 
   def count_publishers_failures, do: Messaging.count_publishers_failures()
 

--- a/lib/postoffice/messaging.ex
+++ b/lib/postoffice/messaging.ex
@@ -238,4 +238,23 @@ defmodule Postoffice.Messaging do
     from(t in Topic, where: t.recovery_enabled == true, distinct: true, select: t.origin_host)
     |> Repo.all()
   end
+
+  @doc """
+  Returns an integer representing an estimated count from the given schema.
+
+  ## Examples
+
+      iex> get_estimate_count("messages")
+      0
+
+  """
+  def get_estimated_count(schema) do
+    IO.puts(schema)
+    Ecto.Adapters.SQL.query!(
+      Postoffice.Repo,
+      "SELECT reltuples::bigint FROM pg_catalog.pg_class WHERE relname = $1;", [schema]
+    ).rows
+    |> List.first
+    |> List.first
+  end
 end

--- a/lib/postoffice_web/controllers/index_controller.ex
+++ b/lib/postoffice_web/controllers/index_controller.ex
@@ -4,8 +4,8 @@ defmodule PostofficeWeb.IndexController do
   def index(conn, _params) do
     render(conn, "index.html",
       topics: Postoffice.count_topics(),
-      messages_received: Postoffice.count_received_messages(),
-      messages_published: Postoffice.count_published_messages(),
+      messages_received: Postoffice.estimated_messages_count(),
+      messages_published: Postoffice.estimated_published_messages_count(),
       publishers_failures: Postoffice.count_publishers_failures(),
       publishers: Postoffice.count_publishers()
     )

--- a/test/postoffice/messaging_test.exs
+++ b/test/postoffice/messaging_test.exs
@@ -366,5 +366,9 @@ defmodule Postoffice.MessagingTest do
 
       assert hosts == []
     end
+
+    test "get_estimate_count returns 0 when no topic exists" do
+      assert Messaging.get_estimated_count("topics") == 0
+    end
   end
 end

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -17,33 +17,17 @@ defmodule Postoffice.PostofficeTest do
     "type" => "pubsub"
   }
 
-  describe "PostofficeWeb external api" do
+  describe "Postoffice api" do
     test "Returns nil if tried to find message by invalid UUID" do
       assert Postoffice.find_message_by_uuid(123) == nil
     end
 
-    test "count_received_messages returns 0 if no message exists" do
-      assert Postoffice.count_received_messages() == 0
+    test "estimated_messages_count returns 0 if no message exists" do
+      assert Postoffice.estimated_messages_count() == 0
     end
 
-    test "count_messages returns number of created messages" do
-      topic = Fixtures.create_topic()
-      Fixtures.add_message_to_deliver(topic)
-
-      assert Postoffice.count_received_messages() == 1
-    end
-
-    test "count_published_messages returns 0 if no published message exists" do
-      assert Postoffice.count_published_messages() == 0
-    end
-
-    test "count_published_messages returns number of published messages" do
-      topic = Fixtures.create_topic()
-      publisher = Fixtures.create_publisher(topic)
-      message = Fixtures.add_message_to_deliver(topic)
-      Fixtures.create_publisher_success(message, publisher)
-
-      assert Postoffice.count_published_messages() == 1
+    test "estimated_published_messages_count returns 0 if no published message exists" do
+      assert Postoffice.estimated_published_messages_count() == 0
     end
 
     test "count_publishers_failures returns 0 if no failed message exists" do


### PR DESCRIPTION
Count performance in Postgres is not really good with tables with a few million rows. The web dashboard was taking a few seconds to load because of it
The important data to take a look is "pending messages", which will be added to the index. As messages and publisher_success are just to give a general view of the status, we'll relly on estimates. This information we'll be updated with vacuum/analyze, so don't expect to see this updated in real-time

The performance improvement is quite good. From almost 2s queries we'll go down to ~40ms actually 