### PR TITLE
Add timeout for http publishers

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,7 +12,8 @@ use Mix.Config
 config :postoffice, PostofficeWeb.Endpoint,
   url: [host: {:system, "HOST", default: "localhost"}, port: 4000],
   cache_static_manifest: "priv/static/cache_manifest.json",
-  server: true
+  server: true,
+  check_origin: false
 
 config :logger_json, :backend, metadata: :all
 config :logger, backends: [LoggerJSON]

--- a/lib/postoffice/adapters/http.ex
+++ b/lib/postoffice/adapters/http.ex
@@ -5,12 +5,18 @@ defmodule Postoffice.Adapters.Http do
   @behaviour Postoffice.Adapters.Impl
 
   @impl true
-  def publish(target, message) do
-    Logger.info("Dispatching Http message to #{target}")
+  def publish(publisher, message) do
+    Logger.info("Dispatching Http message to #{publisher.target}")
     %{payload: payload} = message
 
-    HTTPoison.post(target, Poison.encode!(payload), [
-      {"content-type", "application/json"}
-    ])
+    HTTPoison.post(
+      publisher.target,
+      Poison.encode!(payload),
+      [
+        {"content-type", "application/json"},
+        {"message-id", message.id}
+      ],
+      recv_timeout: publisher.seconds_timeout * 1_000
+    )
   end
 end

--- a/lib/postoffice/adapters/impl.ex
+++ b/lib/postoffice/adapters/impl.ex
@@ -1,7 +1,7 @@
 defmodule Postoffice.Adapters.Impl do
   @moduledoc false
 
-  alias Postoffice.Adapters.Message
+  alias Postoffice.Messaging.Publisher
 
-  @callback publish(String, Message) :: {:ok, Message} | {:error, reason :: String}
+  @callback publish(Publisher, any) :: {:ok, any} | {:error, reason :: String}
 end

--- a/lib/postoffice/adapters/pubsub.ex
+++ b/lib/postoffice/adapters/pubsub.ex
@@ -16,8 +16,8 @@ defmodule Postoffice.Adapters.Pubsub do
     request = %GoogleApi.PubSub.V1.Model.PublishRequest{
       messages: [
         %GoogleApi.PubSub.V1.Model.PubsubMessage{
-          data: Base.encode64(Poison.encode!(payload)),
-          attributes: attributes
+          data: Base.encode64(Poison.encode!(pending_messages.payload)),
+          attributes: pending_messages.attributes
         }
       ]
     }

--- a/lib/postoffice/adapters/pubsub.ex
+++ b/lib/postoffice/adapters/pubsub.ex
@@ -5,9 +5,9 @@ defmodule Postoffice.Adapters.Pubsub do
   @behaviour Postoffice.Adapters.Impl
 
   @impl true
-  def publish(target, message) do
-    Logger.info("Publishing PubSub message to #{target}")
-    %{payload: payload, attributes: attributes} = message
+  def publish(publisher, pending_messages) do
+    Logger.info("Publishing PubSub message to #{publisher.target}")
+
     # Authenticate
     {:ok, token} = Goth.Token.for_scope("https://www.googleapis.com/auth/cloud-platform")
     Logger.info("successfully generated token for pubsub")
@@ -26,7 +26,7 @@ defmodule Postoffice.Adapters.Pubsub do
     GoogleApi.PubSub.V1.Api.Projects.pubsub_projects_topics_publish(
       conn,
       Application.get_env(:postoffice, :pubsub_project_name),
-      target,
+      publisher.target,
       body: request
     )
   end

--- a/lib/postoffice/handlers/http.ex
+++ b/lib/postoffice/handlers/http.ex
@@ -4,20 +4,20 @@ defmodule Postoffice.Handlers.Http do
 
   alias Postoffice.Messaging
 
-  def run(publisher_target, publisher_id, message) do
-    Logger.info("Processing http message", message_id: message.public_id, target: publisher_target)
+  def run(publisher, message) do
+    Logger.info("Processing http message", message_id: message.public_id, target: publisher.target)
 
-    case impl().publish(publisher_target, message) do
+    case impl().publish(publisher, message) do
       {:ok, %HTTPoison.Response{status_code: status_code, body: _body}}
       when status_code in 200..299 ->
         Logger.info("Succesfully sent http message",
           message_id: message.public_id,
-          target: publisher_target
+          target: publisher.target
         )
 
         {:ok, _} =
           Messaging.mark_message_as_delivered(%{
-            publisher_id: publisher_id,
+            publisher_id: publisher.id,
             message_id: message.id
           })
 
@@ -32,7 +32,7 @@ defmodule Postoffice.Handlers.Http do
         Logger.info(error_reason)
 
         Messaging.create_publisher_failure(%{
-          publisher_id: publisher_id,
+          publisher_id: publisher.id,
           message_id: message.id,
           reason: error_reason
         })
@@ -44,7 +44,7 @@ defmodule Postoffice.Handlers.Http do
         Logger.info(error_reason)
 
         Messaging.create_publisher_failure(%{
-          publisher_id: publisher_id,
+          publisher_id: publisher.id,
           message_id: message.id,
           reason: error_reason
         })

--- a/lib/postoffice/handlers/pubsub.ex
+++ b/lib/postoffice/handlers/pubsub.ex
@@ -6,23 +6,22 @@ defmodule Postoffice.Handlers.Pubsub do
   alias GoogleApi.PubSub.V1.Model.PublishResponse
   alias Postoffice.Messaging
 
-  @spec run(any, any, any) :: {:error, :nosent} | {:ok, :sent}
-  def run(publisher_target, publisher_id, message) do
+  def run(publisher, message) do
     Logger.info("Processing pubsub message",
       message_id: message.public_id,
-      target: publisher_target
+      target: publisher.target
     )
 
-    case impl().publish(publisher_target, message) do
+    case impl().publish(publisher, message) do
       {:ok, _response = %PublishResponse{}} ->
         Logger.info("Succesfully sent pubsub message",
           message_id: message.public_id,
-          target: publisher_target
+          target: publisher.target
         )
 
         {:ok, _} =
           Messaging.mark_message_as_delivered(%{
-            publisher_id: publisher_id,
+            publisher_id: publisher.id,
             message_id: message.id
           })
 
@@ -33,7 +32,7 @@ defmodule Postoffice.Handlers.Pubsub do
         Logger.info(error_reason)
 
         Messaging.create_publisher_failure(%{
-          publisher_id: publisher_id,
+          publisher_id: publisher.id,
           message_id: message.id,
           reason: error_reason
         })

--- a/lib/postoffice/messages_consumer.ex
+++ b/lib/postoffice/messages_consumer.ex
@@ -5,11 +5,10 @@ defmodule Postoffice.MessagesConsumer do
   alias Postoffice.Handlers.Http
   alias Postoffice.Handlers.Pubsub
 
-  def start_link(pending_message) do
-    Task.start_link(MessagesConsumer.get_handler_module(pending_message.publisher.type), :run, [
-      pending_message.publisher.target,
-      pending_message.publisher.id,
-      pending_message.message
+  def start_link(%{publisher: publisher, message: message}) do
+    Task.start_link(MessagesConsumer.get_handler_module(publisher.type), :run, [
+      publisher,
+      message
     ])
   end
 

--- a/lib/postoffice/messages_producer.ex
+++ b/lib/postoffice/messages_producer.ex
@@ -43,7 +43,7 @@ defmodule Postoffice.MessagesProducer do
 
       queue =
         Enum.reduce(pending_messages, queue, fn publisher_message, acc ->
-          :queue.in(%{publisher: publisher, message: pending_messages}, acc)
+          :queue.in(%{publisher: publisher, message: publisher_message.message}, acc)
         end)
 
       {events, demand_state} = Dispatch.dispatch_events(queue, pending_demand, [])

--- a/lib/postoffice/messages_producer.ex
+++ b/lib/postoffice/messages_producer.ex
@@ -43,7 +43,7 @@ defmodule Postoffice.MessagesProducer do
 
       queue =
         Enum.reduce(pending_messages, queue, fn publisher_message, acc ->
-          :queue.in(publisher_message, acc)
+          :queue.in(%{publisher: publisher, message: pending_messages}, acc)
         end)
 
       {events, demand_state} = Dispatch.dispatch_events(queue, pending_demand, [])

--- a/lib/postoffice/messaging/publisher.ex
+++ b/lib/postoffice/messaging/publisher.ex
@@ -8,6 +8,7 @@ defmodule Postoffice.Messaging.Publisher do
     field :type, :string
     field :initial_message, :integer
     belongs_to :topic, Postoffice.Messaging.Topic
+    field :seconds_timeout, :integer, default: 5
 
     has_many :publisher_success, Postoffice.Messaging.PublisherSuccess
 
@@ -17,7 +18,7 @@ defmodule Postoffice.Messaging.Publisher do
   @doc false
   def changeset(consumer_http, attrs) do
     consumer_http
-    |> cast(attrs, [:target, :active, :type, :topic_id, :initial_message])
+    |> cast(attrs, [:target, :active, :type, :topic_id, :initial_message, :seconds_timeout])
     |> validate_required([:target, :active, :topic_id, :type, :initial_message])
     |> unique_constraint(:target, name: :publishers_topic_id_target_type_index)
     |> validate_inclusion(:type, Keyword.values(types()))

--- a/lib/postoffice_web/endpoint.ex
+++ b/lib/postoffice_web/endpoint.ex
@@ -7,8 +7,7 @@ defmodule PostofficeWeb.Endpoint do
     signing_salt: "To8iCTxd"
   ]
 
-  socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [session: @session_options]]
+  socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phx.digest
@@ -28,6 +27,7 @@ defmodule PostofficeWeb.Endpoint do
   plug Phoenix.LiveDashboard.RequestLogger,
     param_key: "request_logger",
     cookie_key: "request_logger"
+
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 

--- a/lib/postoffice_web/templates/publisher/edit.html.eex
+++ b/lib/postoffice_web/templates/publisher/edit.html.eex
@@ -10,6 +10,16 @@
     </div>
 
     <div class="form-group">
+      <%= label f, :seconds_timeout, class: "control-label" %>
+      <%= textarea f, :seconds_timeout, class: "form-control", rows: 1 %>
+    </div>
+
+    <div class="form-group">
+      <%= label f, :type, class: "control-label" %>
+      <%= select f, :type, Postoffice.Messaging.Publisher.types, disabled: true, class: "form-control selectpicker" %>
+    </div>
+
+    <div class="form-group">
       <div class="form-check">
           <label class="form-check-label">
               Active
@@ -19,11 +29,6 @@
               </span>
           </label>
       </div>
-    </div>
-
-    <div class="form-group">
-      <%= label f, :type, class: "control-label" %>
-      <%= select f, :type, Postoffice.Messaging.Publisher.types, disabled: true, class: "form-control selectpicker" %>
     </div>
 
     <div class="form-group">

--- a/lib/postoffice_web/templates/publisher/new.html.eex
+++ b/lib/postoffice_web/templates/publisher/new.html.eex
@@ -7,6 +7,21 @@
         </div>
 
         <div class="form-group">
+          <%= label f, :target, class: "control-label" %>
+          <%= textarea f, :target, class: "form-control", rows: 1 %>
+        </div>
+
+        <div class="form-group">
+          <%= label f, :seconds_timeout, class: "control-label" %>
+          <%= textarea f, :seconds_timeout, class: "form-control", rows: 1 %>
+        </div>
+
+        <div class="form-group">
+          <label for="type">Type</label>
+          <%= select f, :type, Postoffice.Messaging.Publisher.types, class: "form-control selectpicker" %>
+        </div>
+
+        <div class="form-group">
           <div class="form-check">
               <label class="form-check-label">
                   Active
@@ -16,16 +31,6 @@
                   </span>
               </label>
           </div>
-        </div>
-
-        <div class="form-group">
-          <%= label f, :target, class: "control-label" %>
-          <%= textarea f, :target, class: "form-control", rows: 1 %>
-        </div>
-
-        <div class="form-group">
-          <label for="type">Type</label>
-          <%= select f, :type, Postoffice.Messaging.Publisher.types, class: "form-control selectpicker" %>
         </div>
 
         <div class="form-group">

--- a/priv/repo/migrations/20200604133742_add_publisher_timeout.exs
+++ b/priv/repo/migrations/20200604133742_add_publisher_timeout.exs
@@ -1,0 +1,9 @@
+defmodule Postoffice.Repo.Migrations.AddPublisherTimeout do
+  use Ecto.Migration
+
+  def change do
+    alter table(:publishers) do
+      add :seconds_timeout, :integer, default: 5
+    end
+  end
+end

--- a/test/postoffice/handlers/http_test.exs
+++ b/test/postoffice/handlers/http_test.exs
@@ -49,11 +49,11 @@ defmodule Postoffice.Handlers.HttpTest do
 
     {:ok, message} = Messaging.add_message_to_deliver(topic, @valid_message_attrs)
 
-    expect(HttpMock, :publish, fn "http://fake.target", ^message ->
+    expect(HttpMock, :publish, fn ^publisher, ^message ->
       {:ok, %HTTPoison.Response{status_code: 404}}
     end)
 
-    Http.run(publisher.target, publisher.id, message)
+    Http.run(publisher, message)
     assert [] = Messaging.list_publisher_success(publisher.id)
     message_failure = List.first(Messaging.list_publisher_failures(publisher.id))
     assert message_failure.message_id == message.id
@@ -70,11 +70,11 @@ defmodule Postoffice.Handlers.HttpTest do
 
     {:ok, message} = Messaging.add_message_to_deliver(topic, @valid_message_attrs)
 
-    expect(HttpMock, :publish, fn "http://fake.target", ^message ->
+    expect(HttpMock, :publish, fn ^publisher, ^message ->
       {:ok, %HTTPoison.Response{status_code: 201}}
     end)
 
-    Http.run(publisher.target, publisher.id, message)
+    Http.run(publisher, message)
     assert [message] = Messaging.list_publisher_success(publisher.id)
   end
 
@@ -85,11 +85,11 @@ defmodule Postoffice.Handlers.HttpTest do
 
     assert length(Repo.all(PendingMessage)) == 1
 
-    expect(HttpMock, :publish, fn "http://fake.target", ^message ->
+    expect(HttpMock, :publish, fn ^publisher, ^message ->
       {:ok, %HTTPoison.Response{status_code: 201}}
     end)
 
-    Http.run(publisher.target, publisher.id, message)
+    Http.run(publisher, message)
     assert length(Repo.all(PendingMessage)) == 0
   end
 
@@ -101,11 +101,11 @@ defmodule Postoffice.Handlers.HttpTest do
 
     assert length(Repo.all(PendingMessage)) == 2
 
-    expect(HttpMock, :publish, fn "http://fake.target", ^message ->
+    expect(HttpMock, :publish, fn ^publisher, ^message ->
       {:ok, %HTTPoison.Response{status_code: 201}}
     end)
 
-    Http.run(publisher.target, publisher.id, message)
+    Http.run(publisher, message)
 
     pending_messages = Messaging.list_pending_messages_for_publisher(publisher.id)
     assert Kernel.length(pending_messages) == 1
@@ -138,11 +138,11 @@ defmodule Postoffice.Handlers.HttpTest do
 
     assert length(Repo.all(PendingMessage)) == 2
 
-    expect(HttpMock, :publish, fn "http://fake.target", ^message ->
+    expect(HttpMock, :publish, fn ^publisher, ^message ->
       {:ok, %HTTPoison.Response{status_code: 201}}
     end)
 
-    Http.run(publisher.target, publisher.id, message)
+    Http.run(publisher, message)
     assert length(Repo.all(PendingMessage)) == 1
 
     pending_message =
@@ -160,11 +160,11 @@ defmodule Postoffice.Handlers.HttpTest do
 
     {:ok, message} = Messaging.add_message_to_deliver(topic, @valid_message_attrs)
 
-    expect(HttpMock, :publish, fn "http://fake.target", ^message ->
+    expect(HttpMock, :publish, fn ^publisher, ^message ->
       {:error, %HTTPoison.Error{reason: "test error reason"}}
     end)
 
-    Http.run(publisher.target, publisher.id, message)
+    Http.run(publisher, message)
     message_failure = List.first(Messaging.list_publisher_failures(publisher.id))
     assert message_failure.message_id == message.id
 
@@ -178,11 +178,11 @@ defmodule Postoffice.Handlers.HttpTest do
 
     {:ok, message} = Messaging.add_message_to_deliver(topic, @valid_message_attrs)
 
-    expect(HttpMock, :publish, fn "http://fake.target", ^message ->
+    expect(HttpMock, :publish, fn ^publisher, ^message ->
       {:error, %HTTPoison.Error{reason: "test error reason"}}
     end)
 
-    Http.run(publisher.target, publisher.id, message)
+    Http.run(publisher, message)
     assert length(Repo.all(PendingMessage)) == 1
   end
 
@@ -194,11 +194,11 @@ defmodule Postoffice.Handlers.HttpTest do
 
     {:ok, message} = Messaging.add_message_to_deliver(topic, @valid_message_attrs)
 
-    expect(HttpMock, :publish, fn "http://fake.target", ^message ->
+    expect(HttpMock, :publish, fn ^publisher, ^message ->
       {:ok, %HTTPoison.Response{status_code: 300}}
     end)
 
-    Http.run(publisher.target, publisher.id, message)
+    Http.run(publisher, message)
     message_failure = List.first(Messaging.list_publisher_failures(publisher.id))
     assert message_failure.message_id == message.id
 

--- a/test/postoffice/handlers/pubsub_test.exs
+++ b/test/postoffice/handlers/pubsub_test.exs
@@ -53,11 +53,11 @@ defmodule Postoffice.Handlers.PubsubTest do
       topic_id: topic.id
     }
 
-    expect(PubsubMock, :publish, fn "test-publisher", ^message ->
+    expect(PubsubMock, :publish, fn ^publisher, ^message ->
       {:error, "test error"}
     end)
 
-    Pubsub.run(publisher.target, publisher.id, message)
+    Pubsub.run(publisher, message)
     assert [] = Messaging.list_publisher_success(publisher.id)
   end
 
@@ -69,11 +69,11 @@ defmodule Postoffice.Handlers.PubsubTest do
 
     {:ok, message} = Messaging.add_message_to_deliver(topic, @valid_message_attrs)
 
-    expect(PubsubMock, :publish, fn "test-publisher", ^message ->
+    expect(PubsubMock, :publish, fn ^publisher, ^message ->
       {:ok, %PublishResponse{}}
     end)
 
-    Pubsub.run(publisher.target, publisher.id, message)
+    Pubsub.run(publisher, message)
     assert [message] = Messaging.list_publisher_success(publisher.id)
   end
 
@@ -85,11 +85,11 @@ defmodule Postoffice.Handlers.PubsubTest do
 
     {:ok, message} = Messaging.add_message_to_deliver(topic, @valid_message_attrs)
 
-    expect(PubsubMock, :publish, fn "test-publisher", ^message ->
+    expect(PubsubMock, :publish, fn ^publisher, ^message ->
       {:error, "Not able to deliver"}
     end)
 
-    Pubsub.run(publisher.target, publisher.id, message)
+    Pubsub.run(publisher, message)
     publisher_failure = List.first(Messaging.list_publisher_failures(publisher.id))
     assert publisher_failure.message_id == message.id
 
@@ -106,11 +106,11 @@ defmodule Postoffice.Handlers.PubsubTest do
 
     assert length(Repo.all(PendingMessage)) == 1
 
-    expect(PubsubMock, :publish, fn "test-publisher", ^message ->
+    expect(PubsubMock, :publish, fn ^publisher, ^message ->
       {:ok, %PublishResponse{}}
     end)
 
-    Pubsub.run(publisher.target, publisher.id, message)
+    Pubsub.run(publisher, message)
     assert length(Repo.all(PendingMessage)) == 0
   end
 
@@ -131,11 +131,11 @@ defmodule Postoffice.Handlers.PubsubTest do
 
     assert length(Repo.all(PendingMessage)) == 2
 
-    expect(PubsubMock, :publish, fn "test-publisher", ^message ->
+    expect(PubsubMock, :publish, fn ^publisher, ^message ->
       {:ok, %PublishResponse{}}
     end)
 
-    Pubsub.run(publisher.target, publisher.id, message)
+    Pubsub.run(publisher, message)
     assert length(Repo.all(PendingMessage)) == 1
 
     pending_message =
@@ -153,11 +153,11 @@ defmodule Postoffice.Handlers.PubsubTest do
 
     assert length(Repo.all(PendingMessage)) == 2
 
-    expect(PubsubMock, :publish, fn "test-publisher", ^message ->
+    expect(PubsubMock, :publish, fn ^publisher, ^message ->
       {:ok, %PublishResponse{}}
     end)
 
-    Pubsub.run(publisher.target, publisher.id, message)
+    Pubsub.run(publisher, message)
     assert length(Repo.all(PendingMessage)) == 1
 
     pending_message =
@@ -172,11 +172,11 @@ defmodule Postoffice.Handlers.PubsubTest do
     publisher = Fixtures.create_publisher(topic, @valid_publisher_attrs)
     message = Fixtures.add_message_to_deliver(topic, @valid_message_attrs)
 
-    expect(PubsubMock, :publish, fn "test-publisher", ^message ->
+    expect(PubsubMock, :publish, fn ^publisher, ^message ->
       {:error, "Not able to deliver"}
     end)
 
-    Pubsub.run(publisher.target, publisher.id, message)
+    Pubsub.run(publisher, message)
     assert length(Repo.all(PendingMessage)) == 1
   end
 end

--- a/test/postoffice/messages_consumer_test.exs
+++ b/test/postoffice/messages_consumer_test.exs
@@ -20,17 +20,17 @@ defmodule Postoffice.MessagesConsumerTest do
   describe "MessagesConsumer tests" do
     test "message from messaging context must be valid for this module" do
       topic = Fixtures.create_topic()
-      publisher = Fixtures.create_publisher(topic)
+      existing_publisher = Fixtures.create_publisher(topic)
       {_, message} = Messaging.add_message_to_deliver(topic, @message_attrs)
 
-      pending_message =
-        Messaging.list_pending_messages_for_publisher(publisher.id) |> List.first()
+      _pending_message =
+        Messaging.list_pending_messages_for_publisher(existing_publisher.id) |> List.first()
 
-      expect(HttpMock, :publish, fn "http://fake.target", ^message ->
+      expect(HttpMock, :publish, fn ^existing_publisher, ^message ->
         {:ok, %HTTPoison.Response{status_code: 200}}
       end)
 
-      MessagesConsumer.start_link(pending_message)
+      MessagesConsumer.start_link(%{publisher: existing_publisher, message: message})
       Process.sleep(300)
     end
   end


### PR DESCRIPTION
Allow specifying timeout for http publishers. Default value will be the same as now (5 seconds), but each publisher will be able to change it if needed.
As it's the first iteration this field is not exposed through API