### PR TITLE
Stop generating uuid for received messages, use message's id instead

### DIFF
--- a/lib/postoffice.ex
+++ b/lib/postoffice.ex
@@ -16,10 +16,7 @@ defmodule Postoffice do
         {:relationship_does_not_exists, %{topic: ["is invalid"]}}
 
       topic ->
-        Messaging.add_message_to_deliver(
-          topic,
-          Map.put_new(message_params, "public_id", Ecto.UUID.generate())
-        )
+        Messaging.add_message_to_deliver(topic, message_params)
     end
   end
 
@@ -63,14 +60,8 @@ defmodule Postoffice do
     |> Messaging.create_publisher()
   end
 
-  def find_message_by_uuid(uuid) do
-    case Ecto.UUID.cast(uuid) do
-      :error ->
-        nil
-
-      _ok ->
-        Messaging.get_message_by_uuid(uuid)
-    end
+  def find_message_by_id(id) do
+    Messaging.get_message!(id)
   end
 
   def get_message(id), do: Messaging.get_message!(id)

--- a/lib/postoffice/handlers/http.ex
+++ b/lib/postoffice/handlers/http.ex
@@ -5,13 +5,13 @@ defmodule Postoffice.Handlers.Http do
   alias Postoffice.Messaging
 
   def run(publisher, message) do
-    Logger.info("Processing http message", message_id: message.public_id, target: publisher.target)
+    Logger.info("Processing http message", message_id: message.id, target: publisher.target)
 
     case impl().publish(publisher, message) do
       {:ok, %HTTPoison.Response{status_code: status_code, body: _body}}
       when status_code in 200..299 ->
         Logger.info("Succesfully sent http message",
-          message_id: message.public_id,
+          message_id: message.id,
           target: publisher.target
         )
 

--- a/lib/postoffice/handlers/pubsub.ex
+++ b/lib/postoffice/handlers/pubsub.ex
@@ -8,14 +8,14 @@ defmodule Postoffice.Handlers.Pubsub do
 
   def run(publisher, message) do
     Logger.info("Processing pubsub message",
-      message_id: message.public_id,
+      message_id: message.id,
       target: publisher.target
     )
 
     case impl().publish(publisher, message) do
       {:ok, _response = %PublishResponse{}} ->
         Logger.info("Succesfully sent pubsub message",
-          message_id: message.public_id,
+          message_id: message.id,
           target: publisher.target
         )
 

--- a/lib/postoffice/messaging.ex
+++ b/lib/postoffice/messaging.ex
@@ -199,11 +199,6 @@ defmodule Postoffice.Messaging do
     |> Repo.all()
   end
 
-  def get_message_by_uuid(message_uuid) do
-    from(m in Message, where: m.public_id == ^message_uuid)
-    |> Repo.one()
-  end
-
   def count_topics do
     Repo.aggregate(from(t in "topics"), :count, :id)
   end

--- a/lib/postoffice/messaging/message.ex
+++ b/lib/postoffice/messaging/message.ex
@@ -5,7 +5,6 @@ defmodule Postoffice.Messaging.Message do
   schema "messages" do
     field :attributes, :map
     field :payload, :map
-    field :public_id, Ecto.UUID
     belongs_to :topic, Postoffice.Messaging.Topic
 
     has_many :publisher_success, Postoffice.Messaging.PublisherSuccess
@@ -20,7 +19,7 @@ defmodule Postoffice.Messaging.Message do
   @doc false
   def changeset(message, attrs) do
     message
-    |> cast(attrs, [:payload, :attributes, :public_id])
-    |> validate_required([:payload, :attributes, :public_id])
+    |> cast(attrs, [:payload, :attributes])
+    |> validate_required([:payload, :attributes])
   end
 end

--- a/lib/postoffice/rescuer/message_recovery.ex
+++ b/lib/postoffice/rescuer/message_recovery.ex
@@ -45,8 +45,8 @@ defmodule Postoffice.Rescuer.MessageRecovery do
     case Postoffice.receive_message(message_params) do
       {:ok, created_message} ->
         Logger.info(
-          "Successfully recovered message for topic #{created_message.topic_id} with public_id #{
-            created_message.public_id
+          "Successfully recovered message for topic #{created_message.topic_id} with id #{
+            created_message.id
           }"
         )
 

--- a/lib/postoffice_web/controllers/message_controller.ex
+++ b/lib/postoffice_web/controllers/message_controller.ex
@@ -1,8 +1,8 @@
 defmodule PostofficeWeb.MessageController do
   use PostofficeWeb, :controller
 
-  def index(conn, %{"uuid" => uuid}) do
-    case Postoffice.find_message_by_uuid(uuid) do
+  def index(conn, %{"id" => id}) do
+    case Postoffice.find_message_by_id(id) do
       nil ->
         conn
         |> put_flash(:info, "Message not found")

--- a/lib/postoffice_web/templates/layout/app.html.eex
+++ b/lib/postoffice_web/templates/layout/app.html.eex
@@ -59,7 +59,7 @@
             <%= form_for @conn, Routes.message_path(@conn, :index), [method: :get, class: "navbar-form"],fn _f -> %>
               <span class="bmd-form-group">
                 <div class="input-group no-border">
-                  <input type="text" id="uuid" name="uuid" value="" class="form-control" placeholder="Search message uuid">
+                  <input type="text" id="id" name="id" value="" class="form-control" placeholder="Search message by id">
                   <button type="submit" class="btn btn-white btn-round btn-just-icon">
                     <i class="material-icons">search</i>
                     <div class="ripple-container"></div>

--- a/lib/postoffice_web/templates/message/show.html.eex
+++ b/lib/postoffice_web/templates/message/show.html.eex
@@ -1,4 +1,4 @@
-<h4>Message: <%= @message.public_id %></h4>
+<h4>Message: <%= @message.id %></h4>
 <div class="row">
   <div class="col-md-6">
     <table class="table table-bordered">

--- a/lib/postoffice_web/views/api/message_view.ex
+++ b/lib/postoffice_web/views/api/message_view.ex
@@ -12,7 +12,7 @@ defmodule PostofficeWeb.Api.MessageView do
 
   def render("message.json", %{message: message}) do
     %{
-      public_id: message.public_id
+      id: message.id
     }
   end
 

--- a/priv/repo/migrations/20200609132329_remove_message_uuid_field.exs
+++ b/priv/repo/migrations/20200609132329_remove_message_uuid_field.exs
@@ -1,0 +1,9 @@
+defmodule Postoffice.Repo.Migrations.RemoveMessageUuidField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:messages) do
+      remove :public_id
+    end
+  end
+end

--- a/test/postoffice/handlers/http_test.exs
+++ b/test/postoffice/handlers/http_test.exs
@@ -12,8 +12,7 @@ defmodule Postoffice.Handlers.HttpTest do
 
   @valid_message_attrs %{
     attributes: %{},
-    payload: %{},
-    public_id: "7488a646-e31f-11e4-aace-600308960662"
+    payload: %{}
   }
 
   @valid_publisher_attrs %{
@@ -31,8 +30,7 @@ defmodule Postoffice.Handlers.HttpTest do
 
   @another_valid_message_attrs %{
     attributes: %{},
-    payload: %{},
-    public_id: "7488a646-e31f-11e4-aace-600308960661"
+    payload: %{}
   }
 
   setup [:set_mox_from_context, :verify_on_exit!]

--- a/test/postoffice/handlers/pubsub_test.exs
+++ b/test/postoffice/handlers/pubsub_test.exs
@@ -14,13 +14,11 @@ defmodule Postoffice.Handlers.PubsubTest do
 
   @valid_message_attrs %{
     attributes: %{"attr" => "some_value"},
-    payload: %{"key" => "value"},
-    public_id: "7488a646-e31f-11e4-aace-600308960662"
+    payload: %{"key" => "value"}
   }
   @another_valid_message_attrs %{
     attributes: %{"attr" => "some_value"},
-    payload: %{"key" => "value"},
-    public_id: "7488a646-e31f-11e4-aace-600308960661"
+    payload: %{"key" => "value"}
   }
   @valid_publisher_attrs %{
     active: true,
@@ -49,7 +47,6 @@ defmodule Postoffice.Handlers.PubsubTest do
     message = %Message{
       attributes: %{},
       payload: %{},
-      public_id: "7488a646-e31f-11e4-aace-600308960662",
       topic_id: topic.id
     }
 

--- a/test/postoffice/messages_consumer_test.exs
+++ b/test/postoffice/messages_consumer_test.exs
@@ -11,8 +11,7 @@ defmodule Postoffice.MessagesConsumerTest do
 
   @message_attrs %{
     attributes: %{},
-    payload: %{},
-    public_id: "7488a646-e31f-11e4-aace-600308960662"
+    payload: %{}
   }
 
   setup [:set_mox_from_context, :verify_on_exit!]

--- a/test/postoffice/messaging_test.exs
+++ b/test/postoffice/messaging_test.exs
@@ -21,8 +21,7 @@ defmodule Postoffice.MessagingTest do
 
   @message_attrs %{
     attributes: %{},
-    payload: %{},
-    public_id: "7488a646-e31f-11e4-aace-600308960662"
+    payload: %{}
   }
 
   @second_publisher_attrs %{
@@ -32,7 +31,7 @@ defmodule Postoffice.MessagingTest do
     type: "http"
   }
 
-  @invalid_message_attrs %{attributes: nil, payload: nil, public_id: nil, topic: nil}
+  @invalid_message_attrs %{attributes: nil, payload: nil, topic: nil}
 
   describe "messages" do
     test "list_messages/0 returns all messages" do
@@ -50,11 +49,7 @@ defmodule Postoffice.MessagingTest do
       topic = Fixtures.create_topic()
       message = Fixtures.add_message_to_deliver(topic)
 
-      _second_message =
-        Fixtures.add_message_to_deliver(topic, %{
-          @message_attrs
-          | public_id: "7488a646-e31f-11e4-aace-600308960661"
-        })
+      Fixtures.add_message_to_deliver(topic, @message_attrs)
 
       assert Messaging.list_messages(1) == [message]
     end
@@ -73,7 +68,6 @@ defmodule Postoffice.MessagingTest do
       assert {:ok, %Message{} = message} = Messaging.add_message_to_deliver(topic, @message_attrs)
       assert message.attributes == %{}
       assert message.payload == %{}
-      assert message.public_id == "7488a646-e31f-11e4-aace-600308960662"
       assert message.topic_id == topic.id
     end
 
@@ -175,14 +169,6 @@ defmodule Postoffice.MessagingTest do
       assert enabled_publisher.target == listed_publisher.target
       assert enabled_publisher.active == listed_publisher.active
       assert enabled_publisher.type == listed_publisher.type
-    end
-
-    test "get_message_by_uuid returns message is found" do
-      topic = Fixtures.create_topic()
-      message = Fixtures.add_message_to_deliver(topic)
-      searched_message = Messaging.get_message_by_uuid(message.public_id)
-
-      assert message.id == searched_message.id
     end
 
     test "list_pending_messages_for_publisher/2 returns empty if no pending messages for a given publisher" do

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -18,10 +18,6 @@ defmodule Postoffice.PostofficeTest do
   }
 
   describe "Postoffice api" do
-    test "Returns nil if tried to find message by invalid UUID" do
-      assert Postoffice.find_message_by_uuid(123) == nil
-    end
-
     test "estimated_messages_count returns 0 if no message exists" do
       assert Postoffice.estimated_messages_count() == 0
     end

--- a/test/postoffice_web/controllers/api/message_controller_test.exs
+++ b/test/postoffice_web/controllers/api/message_controller_test.exs
@@ -21,9 +21,9 @@ defmodule PostofficeWeb.Api.MessageControllerTest do
   end
 
   describe "create message" do
-    test "renders message when data is valid", %{conn: conn} do
+    test "returns 201 when data is valid", %{conn: conn} do
       conn = post(conn, Routes.api_message_path(conn, :create), @create_attrs)
-      assert %{"public_id" => id} = json_response(conn, 201)["data"]
+      assert json_response(conn, 201)
     end
 
     test "renders errors when topic does not exists", %{conn: conn} do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -14,8 +14,7 @@ defmodule Postoffice.Fixtures do
 
   @message_attrs %{
     attributes: %{},
-    payload: %{},
-    public_id: "7488a646-e31f-11e4-aace-600308960662"
+    payload: %{}
   }
 
   @publisher_attrs %{


### PR DESCRIPTION
Message's UUID does not give us any real value but we're wasting resources generating it. Remove it and use message's id everywhere 