### PR TITLE
Insert messages in bulk

### DIFF
--- a/lib/postoffice.ex
+++ b/lib/postoffice.ex
@@ -20,6 +20,14 @@ defmodule Postoffice do
     end
   end
 
+  def receive_messages(%{"topic" => topic, "attributes" => attributes, "payload" => payload} = params) do
+    messages_params = Enum.map(payload, fn message_payload ->
+      %{attributes: attributes, payload: message_payload}
+    end)
+
+    Messaging.add_messages_to_deliver(topic, messages_params)
+  end
+
   def create_topic(topic_params) do
     Messaging.create_topic(topic_params)
   end

--- a/lib/postoffice.ex
+++ b/lib/postoffice.ex
@@ -20,10 +20,13 @@ defmodule Postoffice do
     end
   end
 
-  def receive_messages(%{"topic" => topic, "attributes" => attributes, "payload" => payload} = params) do
-    messages_params = Enum.map(payload, fn message_payload ->
-      %{attributes: attributes, payload: message_payload}
-    end)
+  def receive_messages(
+        %{"topic" => topic, "attributes" => attributes, "payload" => payload} = params
+      ) do
+    messages_params =
+      Enum.map(payload, fn message_payload ->
+        %{attributes: attributes, payload: message_payload}
+      end)
 
     Messaging.add_messages_to_deliver(topic, messages_params)
   end

--- a/lib/postoffice/messaging.ex
+++ b/lib/postoffice/messaging.ex
@@ -78,6 +78,14 @@ defmodule Postoffice.Messaging do
     end
   end
 
+  defp build_message_changeset(topic, message) when is_list(message) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    Enum.map(message, fn message_attrs ->
+      Map.merge(message_attrs, %{topic_id: topic.id, inserted_at: now, updated_at: now})
+    end)
+  end
+
   defp build_message_changeset(topic, message) do
     Ecto.build_assoc(topic, :messages, message)
     |> Message.changeset(message)
@@ -92,6 +100,41 @@ defmodule Postoffice.Messaging do
       |> PendingMessage.changeset(%{})
       |> Repo.insert!()
     end)
+  end
+
+  def add_messages_to_deliver(topic_name, messages_attrs) do
+      case __MODULE__.get_topic(topic_name) |> Repo.preload(:consumers) do
+      nil ->
+        {:error, "Topic does not exist"}
+      topic ->
+        Ecto.Multi.new()
+          |> Ecto.Multi.insert_all(:message, Message, build_message_changeset(topic, messages_attrs), returning: [:id])
+          |> Ecto.Multi.run(:pending_messages, fn _repo, message ->
+            insert_bulk_pending_messages(topic.consumers, message)
+            {:ok, :multiple_insertion}
+          end)
+          |> Repo.transaction()
+          |> case do
+            {:ok, result} -> {:ok, result.message}
+            {:error, :message, changeset, %{}} -> {:error, changeset}
+          end
+    end
+  end
+
+  defp insert_bulk_pending_messages(consumers, data) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    message = data.message |> elem(1)
+    pending_messages = Enum.map(message, fn m ->
+      Enum.map(consumers, fn consumer ->
+        %{publisher_id: consumer.id, message_id: m.id, inserted_at: now, updated_at: now}
+      end)
+    end)
+    |> List.first()
+
+    Ecto.Multi.new()
+      |> Ecto.Multi.insert_all(:pending_messages, PendingMessage, pending_messages)
+      |> Repo.transaction()
   end
 
   @doc """
@@ -235,6 +278,7 @@ defmodule Postoffice.Messaging do
 
   def get_topic(name) do
     from(t in Topic, where: t.name == ^name)
+    # |> Repo.preload(:consumers)
     |> Repo.one()
   end
 

--- a/lib/postoffice/messaging.ex
+++ b/lib/postoffice/messaging.ex
@@ -103,7 +103,7 @@ defmodule Postoffice.Messaging do
   end
 
   def add_messages_to_deliver(topic_name, messages_attrs) do
-    case __MODULE__.get_topic(topic_name) |> Repo.preload(:consumers) do
+    case get_topic(topic_name) |> Repo.preload(:consumers) do
       nil ->
         {:error, "Topic does not exist"}
 
@@ -286,7 +286,6 @@ defmodule Postoffice.Messaging do
 
   def get_topic(name) do
     from(t in Topic, where: t.name == ^name)
-    # |> Repo.preload(:consumers)
     |> Repo.one()
   end
 

--- a/lib/postoffice_web/controllers/api/bulk_message_controller.ex
+++ b/lib/postoffice_web/controllers/api/bulk_message_controller.ex
@@ -4,16 +4,12 @@ defmodule PostofficeWeb.Api.BulkMessageController do
   action_fallback PostofficeWeb.Api.FallbackController
 
   def create(conn, message_params) do
-    inserted_messages =
-      Enum.map(message_params["_json"], fn message -> Postoffice.receive_message(message) end)
-
-    case Enum.all?(inserted_messages, fn {status, _message} -> status == :ok end) do
-      true ->
+    case Postoffice.receive_messages(message_params) do
+      {:ok, _res} ->
         conn
         |> put_status(:created)
         |> render("show.json")
-
-      false ->
+      {:error, _reason} ->
         conn
         |> put_status(:not_acceptable)
         |> render("error.json", error: "Not all messages were inserted")

--- a/lib/postoffice_web/controllers/api/bulk_message_controller.ex
+++ b/lib/postoffice_web/controllers/api/bulk_message_controller.ex
@@ -9,6 +9,7 @@ defmodule PostofficeWeb.Api.BulkMessageController do
         conn
         |> put_status(:created)
         |> render("show.json")
+
       {:error, _reason} ->
         conn
         |> put_status(:not_acceptable)

--- a/test/postoffice/messaging_test.exs
+++ b/test/postoffice/messaging_test.exs
@@ -95,7 +95,7 @@ defmodule Postoffice.MessagingTest do
 
     test "add_messages_to_deliver/2 with 2 messages creates 2 messages entries" do
       topic = Fixtures.create_topic()
-      _publisher = Fixtures.create_publisher(topic)
+      Fixtures.create_publisher(topic)
 
       Messaging.add_messages_to_deliver(topic.name, [@message_attrs, @message_attrs])
 
@@ -104,8 +104,8 @@ defmodule Postoffice.MessagingTest do
 
     test "add_messages_to_deliver/2 with 2 messages creates 2 pending messages entries" do
       topic = Fixtures.create_topic()
-      _publisher = Fixtures.create_publisher(topic)
-      _second_publisher = Fixtures.create_publisher(topic, @second_publisher_attrs)
+      Fixtures.create_publisher(topic)
+      Fixtures.create_publisher(topic, @second_publisher_attrs)
 
       Messaging.add_messages_to_deliver(topic.name, [@message_attrs, @message_attrs])
 
@@ -217,8 +217,8 @@ defmodule Postoffice.MessagingTest do
       publisher = Fixtures.create_publisher(topic)
 
       second_topic = Fixtures.create_topic(@second_topic_attrs)
-      _second_publisher = Fixtures.create_publisher(second_topic, @second_publisher_attrs)
-      _message = Fixtures.add_message_to_deliver(second_topic)
+      Fixtures.create_publisher(second_topic, @second_publisher_attrs)
+      Fixtures.add_message_to_deliver(second_topic)
 
       assert Messaging.list_pending_messages_for_publisher(publisher.id) == []
     end
@@ -258,7 +258,7 @@ defmodule Postoffice.MessagingTest do
     end
 
     test "count_topics returns number of created topics" do
-      _topic = Fixtures.create_topic()
+      Fixtures.create_topic()
 
       assert Messaging.count_topics() == 1
     end
@@ -269,8 +269,8 @@ defmodule Postoffice.MessagingTest do
 
     test "count_publishers returns number of created publishers" do
       topic = Fixtures.create_topic()
-      _publisher = Fixtures.create_publisher(topic)
-      _publisher = Fixtures.create_publisher(topic, @second_publisher_attrs)
+      Fixtures.create_publisher(topic)
+      Fixtures.create_publisher(topic, @second_publisher_attrs)
 
       assert Messaging.count_publishers() == 2
     end
@@ -316,7 +316,7 @@ defmodule Postoffice.MessagingTest do
       topic = Fixtures.create_topic()
       message = Fixtures.add_message_to_deliver(topic)
       publisher = Fixtures.create_publisher(topic)
-      _publisher_success = Fixtures.create_publisher_success(message, publisher)
+      Fixtures.create_publisher_success(message, publisher)
 
       loaded_publisher_success = Messaging.get_publisher_success_for_message(message.id)
       assert Kernel.length(loaded_publisher_success) == 1
@@ -337,17 +337,16 @@ defmodule Postoffice.MessagingTest do
       topic = Fixtures.create_topic()
       message = Fixtures.add_message_to_deliver(topic)
       publisher = Fixtures.create_publisher(topic)
-      _publisher_failures = Fixtures.create_publishers_failure(message, publisher)
+      Fixtures.create_publishers_failure(message, publisher)
 
       loaded_publisher_failures = Messaging.get_publisher_failures_for_message(message.id)
       assert Kernel.length(loaded_publisher_failures) == 1
     end
 
     test "get_recovery_hosts returns unique hosts" do
-      _topic = Fixtures.create_topic()
+      Fixtures.create_topic()
 
-      _second_topic =
-        Fixtures.create_topic(%{
+      Fixtures.create_topic(%{
           name: "second_test",
           origin_host: "example.com"
         })

--- a/test/postoffice/messaging_test.exs
+++ b/test/postoffice/messaging_test.exs
@@ -93,6 +93,25 @@ defmodule Postoffice.MessagingTest do
       assert second_pending_message.message.id == message.id
     end
 
+    test "add_messages_to_deliver/2 with 2 messages creates 2 messages entries" do
+      topic = Fixtures.create_topic()
+      _publisher = Fixtures.create_publisher(topic)
+
+      Messaging.add_messages_to_deliver(topic.name, [@message_attrs, @message_attrs])
+
+      assert length(Repo.all(Message)) == 2
+    end
+
+    test "add_messages_to_deliver/2 with 2 messages creates 2 pending messages entries" do
+      topic = Fixtures.create_topic()
+      _publisher = Fixtures.create_publisher(topic)
+      _second_publisher = Fixtures.create_publisher(topic, @second_publisher_attrs)
+
+      Messaging.add_messages_to_deliver(topic.name, [@message_attrs, @message_attrs])
+
+      assert length(Repo.all(PendingMessage)) == 2
+    end
+
     test "add_message_to_deliver/1 with valid data do not create pending message if have not associated publisher" do
       topic = Fixtures.create_topic()
       second_topic = Fixtures.create_topic(@second_topic_attrs)

--- a/test/postoffice_web/controllers/api/bulk_message_controller_test.exs
+++ b/test/postoffice_web/controllers/api/bulk_message_controller_test.exs
@@ -3,30 +3,18 @@ defmodule PostofficeWeb.Api.BulkMessageControllerTest do
 
   alias Postoffice.Messaging
 
-  @bulk_create_attrs %{
-    _json: [
-      %{
-        attributes: %{},
-        payload: %{"key" => "test1", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]},
-        topic: "test"
-      },
-      %{
-        attributes: %{},
-        payload: %{"key" => "test2", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]},
-        topic: "test"
-      }
-    ]
+  @wrong_topic_create_attrs %{
+    attributes: %{},
+    payload: %{"key" => "test1", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]},
+    topic: "test2"
   }
 
-  @wrong_topic_create_attrs %{
-    _json: [
-      %{
-        attributes: %{},
-        payload: %{"key" => "test1", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]},
-        topic: "test2"
-      }
-    ]
+  @create_attrs %{
+    attributes: %{},
+    payload: [%{"key" => "test", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]}, %{"key" => "test", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]}],
+    topic: "test"
   }
+
 
   setup %{conn: conn} do
     {:ok, _topic} = Messaging.create_topic(%{name: "test", origin_host: "example.com"})
@@ -35,7 +23,7 @@ defmodule PostofficeWeb.Api.BulkMessageControllerTest do
 
   describe "create bulk message" do
     test "accept more than one message", %{conn: conn} do
-      conn = post(conn, Routes.api_bulk_message_path(conn, :create), @bulk_create_attrs)
+      conn = post(conn, Routes.api_bulk_message_path(conn, :create), @create_attrs)
 
       assert json_response(conn, 201)
       assert Kernel.length(Messaging.list_messages()) == 2

--- a/test/postoffice_web/controllers/api/bulk_message_controller_test.exs
+++ b/test/postoffice_web/controllers/api/bulk_message_controller_test.exs
@@ -11,10 +11,12 @@ defmodule PostofficeWeb.Api.BulkMessageControllerTest do
 
   @create_attrs %{
     attributes: %{},
-    payload: [%{"key" => "test", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]}, %{"key" => "test", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]}],
+    payload: [
+      %{"key" => "test", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]},
+      %{"key" => "test", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]}
+    ],
     topic: "test"
   }
-
 
   setup %{conn: conn} do
     {:ok, _topic} = Messaging.create_topic(%{name: "test", origin_host: "example.com"})


### PR DESCRIPTION
We already had an endpoint to receive a batch of messages, but internally we were just iterating and inserting messages individually. 
Now all messages are inserted at once, with a huge performance improvement. 