### PR TITLE
Show failing messages quantity taken from failing cache

### DIFF
--- a/lib/postoffice.ex
+++ b/lib/postoffice.ex
@@ -88,7 +88,10 @@ defmodule Postoffice do
 
   def estimated_published_messages_count, do: Messaging.get_estimated_count("publisher_success")
 
-  def count_publishers_failures, do: Messaging.count_publishers_failures_aggregated()
+  def count_publishers_failures do
+    {:ok, keys} = Cachex.keys(:retry_cache)
+    Kernel.length(keys)
+  end
 
   def count_publishers, do: Messaging.count_publishers()
 

--- a/lib/postoffice_web/templates/index/index.html.eex
+++ b/lib/postoffice_web/templates/index/index.html.eex
@@ -97,7 +97,7 @@
         <div class="card-icon">
           <i class="material-icons">sms_failed</i>
         </div>
-        <p class="card-category">Failed messages</p>
+        <p class="card-category">Failing messages</p>
         <h3 class="card-title"><%= @publishers_failures %>
         </h3>
       </div>

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -20,14 +20,17 @@ defmodule Postoffice.PostofficeTest do
     end
 
     test "count_publishers_failures returns 0 if no failed message exists" do
+      Cachex.reset!(:retry_cache)
       assert Postoffice.count_publishers_failures() == 0
     end
 
     test "count_publishers_failures returns number of failed messages" do
-      topic = Fixtures.create_topic()
-      publisher = Fixtures.create_publisher(topic)
-      message = Fixtures.add_message_to_deliver(topic)
-      Fixtures.create_publishers_failure(message, publisher)
+      Cachex.reset!(:retry_cache)
+      publisher_id = 1
+      message_id = 2
+      Cachex.put(:retry_cache, {publisher_id, message_id}, 1,
+        ttl: :timer.seconds(1)
+      )
 
       assert Postoffice.count_publishers_failures() == 1
     end


### PR DESCRIPTION
Instead of querying the database to take the number of failed messages (could be messages already sent but failed at some point) now we take this information from our cache where each key is a failing message