### PR TITLE
Distributed failures cache

### DIFF
--- a/lib/postoffice/application.ex
+++ b/lib/postoffice/application.ex
@@ -23,7 +23,8 @@ defmodule Postoffice.Application do
       Postoffice.MessagesProducerSupervisor,
       Postoffice.Rescuer.Producer,
       Postoffice.Rescuer.Supervisor,
-      {Cachex, :retry_cache}
+      {Cachex, :retry_cache},
+      Postoffice.Cachex
     ]
 
     :ok =

--- a/lib/postoffice/cachex.ex
+++ b/lib/postoffice/cachex.ex
@@ -22,7 +22,6 @@ defmodule Postoffice.Cachex do
     {:noreply, state}
   end
 
-
   @impl true
   def handle_info({:message_failure, {values, seconds_retry}}, state) when is_list(values) do
     Cachex.put_many(:retry_cache, values, ttl: :timer.seconds(seconds_retry))
@@ -34,6 +33,7 @@ defmodule Postoffice.Cachex do
     Cachex.put(:retry_cache, {publisher_id, pending_message_id}, 1,
       ttl: :timer.seconds(seconds_retry)
     )
+
     {:noreply, state}
   end
 end

--- a/lib/postoffice/cachex.ex
+++ b/lib/postoffice/cachex.ex
@@ -1,0 +1,39 @@
+defmodule Postoffice.Cachex do
+  # This process is in charge of keeping a local cache for failed messages so in case of a node
+  # is down, the others can continue sending messages with the same restrictions.
+  @moduledoc false
+
+  use GenServer
+  alias Phoenix.PubSub
+
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, %{}, name: :postoffice_cachex)
+  end
+
+  @impl true
+  def init(_args) do
+    Process.send_after(self(), :subscribe, 100)
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:subscribe, state) do
+    PubSub.subscribe(Postoffice.PubSub, "messages")
+    {:noreply, state}
+  end
+
+
+  @impl true
+  def handle_info({:message_failure, {values, seconds_retry}}, state) when is_list(values) do
+    Cachex.put_many(:retry_cache, values, ttl: :timer.seconds(seconds_retry))
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:message_failure, {publisher_id, pending_message_id, seconds_retry}}, state) do
+    Cachex.put(:retry_cache, {publisher_id, pending_message_id}, 1,
+      ttl: :timer.seconds(seconds_retry)
+    )
+    {:noreply, state}
+  end
+end

--- a/lib/postoffice/handlers/http.ex
+++ b/lib/postoffice/handlers/http.ex
@@ -3,6 +3,7 @@ defmodule Postoffice.Handlers.Http do
   require Logger
 
   alias Postoffice.Messaging
+  alias Postoffice.PubSub
 
   def run(publisher, pending_message) do
     message = pending_message.message
@@ -63,8 +64,10 @@ defmodule Postoffice.Handlers.Http do
   end
 
   defp cache_failed_message(publisher, pending_message) do
-    Cachex.put(:retry_cache, {publisher.id, pending_message.id}, 1,
-      ttl: :timer.seconds(publisher.seconds_retry)
+    Phoenix.PubSub.broadcast(
+      Postoffice.PubSub,
+      "messages",
+      {:message_failure, {publisher.id, pending_message.id, publisher.seconds_retry}}
     )
   end
 end

--- a/lib/postoffice/handlers/pubsub.ex
+++ b/lib/postoffice/handlers/pubsub.ex
@@ -56,6 +56,10 @@ defmodule Postoffice.Handlers.Pubsub do
         {{publisher.id, pending_message_id}, 1}
       end)
 
-    Cachex.put_many(:retry_cache, values, ttl: :timer.seconds(publisher.seconds_retry))
+    Phoenix.PubSub.broadcast(
+      Postoffice.PubSub,
+      "messages",
+      {:message_failure, {values, publisher.seconds_retry}}
+    )
   end
 end

--- a/lib/postoffice_web/controllers/index_controller.ex
+++ b/lib/postoffice_web/controllers/index_controller.ex
@@ -7,11 +7,15 @@ defmodule PostofficeWeb.IndexController do
     render(conn, "index.html",
       page_name: "Dashboard",
       topics: Delimit.number_to_delimited(Postoffice.count_topics(), precision: 0),
-      messages_received: Delimit.number_to_delimited(Postoffice.estimated_messages_count(), precision: 0),
-      messages_published: Delimit.number_to_delimited(Postoffice.estimated_published_messages_count(), precision: 0),
-      publishers_failures: Delimit.number_to_delimited(Postoffice.count_publishers_failures(), precision: 0),
+      messages_received:
+        Delimit.number_to_delimited(Postoffice.estimated_messages_count(), precision: 0),
+      messages_published:
+        Delimit.number_to_delimited(Postoffice.estimated_published_messages_count(), precision: 0),
+      publishers_failures:
+        Delimit.number_to_delimited(Postoffice.count_publishers_failures(), precision: 0),
       publishers: Delimit.number_to_delimited(Postoffice.count_publishers(), precision: 0),
-      pending_messages: Delimit.number_to_delimited(Postoffice.count_pending_messages(), precision: 0)
+      pending_messages:
+        Delimit.number_to_delimited(Postoffice.count_pending_messages(), precision: 0)
     )
   end
 end

--- a/test/postoffice/handlers/http_test.exs
+++ b/test/postoffice/handlers/http_test.exs
@@ -299,6 +299,7 @@ defmodule Postoffice.Handlers.HttpTest do
     end)
 
     Http.run(publisher, pending_message)
+    :timer.sleep(100)
     {:ok, keys} = Cachex.keys(:retry_cache)
     assert {publisher.id, pending_message.id} in keys
   end
@@ -326,6 +327,7 @@ defmodule Postoffice.Handlers.HttpTest do
 
     Http.run(publisher, pending_message)
     _message_failure = List.first(Messaging.list_publisher_failures(publisher.id))
+    :timer.sleep(100)
     {:ok, keys} = Cachex.keys(:retry_cache)
     assert {publisher.id, pending_message.id} in keys
   end

--- a/test/postoffice/handlers/pubsub_test.exs
+++ b/test/postoffice/handlers/pubsub_test.exs
@@ -226,6 +226,7 @@ defmodule Postoffice.Handlers.PubsubTest do
     end)
 
     Pubsub.run(publisher, pending_messages)
+    :timer.sleep(100)
     {:ok, keys} = Cachex.keys(:retry_cache)
 
     Enum.each(pending_messages, fn pending_message ->

--- a/test/postoffice/messages_producer_test.exs
+++ b/test/postoffice/messages_producer_test.exs
@@ -14,7 +14,10 @@ defmodule Postoffice.MessagesProducerTest do
       existing_publisher = Fixtures.create_publisher(topic)
 
       {:noreply, messages, %{demand_state: {queue, pending_demand}, publisher: _publisher}} =
-        MessagesProducer.handle_demand(1, %{demand_state: {:queue.new(), 0}, publisher: existing_publisher})
+        MessagesProducer.handle_demand(1, %{
+          demand_state: {:queue.new(), 0},
+          publisher: existing_publisher
+        })
 
       assert messages == []
       assert pending_demand == 1
@@ -30,7 +33,10 @@ defmodule Postoffice.MessagesProducerTest do
       state_queue = :queue.in(message, state_queue)
 
       {:noreply, events, %{demand_state: {queue, pending_demand}, publisher: _publisher}} =
-        MessagesProducer.handle_demand(1, %{demand_state: {state_queue, 0}, publisher: existing_publisher})
+        MessagesProducer.handle_demand(1, %{
+          demand_state: {state_queue, 0},
+          publisher: existing_publisher
+        })
 
       assert pending_demand == 0
       assert :queue.len(queue) == 1

--- a/test/postoffice/postoffice_test.exs
+++ b/test/postoffice/postoffice_test.exs
@@ -28,9 +28,7 @@ defmodule Postoffice.PostofficeTest do
       Cachex.reset!(:retry_cache)
       publisher_id = 1
       message_id = 2
-      Cachex.put(:retry_cache, {publisher_id, message_id}, 1,
-        ttl: :timer.seconds(1)
-      )
+      Cachex.put(:retry_cache, {publisher_id, message_id}, 1, ttl: :timer.seconds(1))
 
       assert Postoffice.count_publishers_failures() == 1
     end

--- a/test/postoffice/publisher_producer_test.exs
+++ b/test/postoffice/publisher_producer_test.exs
@@ -20,7 +20,7 @@ defmodule Postoffice.PublisherProducerTest do
 
     test "active publisher loaded on internal state and ready to be consumed" do
       topic = Fixtures.create_topic()
-      existing_publisher = Fixtures.create_publisher(topic)
+      _existing_publisher = Fixtures.create_publisher(topic)
 
       {:noreply, publishers, {queue, pending_demand}} =
         PublisherProducer.handle_info(:populate_state, {:queue.new(), 0})


### PR DESCRIPTION
Instead of caching failures, we'll broadcast the failure event. Each node will keep a local copy of our failure's cache so in case a node is down others can continue sending messages with similar restrictions 