### PR TITLE
Limit message bulk ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ To start your Phoenix server:
   * Create the following environmet variables in order to start the application:
     * `GOOGLE_APPLICATION_CREDENTIALS` with the absolute path to the pubsub credentials file. We provide `config/dummy-credentials.json` to be able to start the app.
     * `GCLOUD_PUBSUB_PROJECT_ID` with the project_id used.
+    * `MAX_BULK_MESSAGES` with the max number of messages that postoffice is able to consume
   * `mix local.hex`
   * `mix archive.install hex phx_new 1.4.11`
   * Install dependencies with `mix deps.get`

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -4,6 +4,7 @@ config :postoffice, PostofficeWeb.Endpoint,
   secret_key_base: {:system, "SECRET_KEY_BASE", default: "12121212"}
 
 config :postoffice, pubsub_project_name: {:system, "GCLOUD_PUBSUB_PROJECT_ID", default: "test"}
+config :postoffice, max_bulk_messages: {:system, "MAX_BULK_MESSAGES", default: 3000}
 
 config :postoffice, Postoffice.Repo,
   username: {:system, "DB_USERNAME", default: "postgres"},

--- a/test/postoffice_web/controllers/api/bulk_message_controller_test.exs
+++ b/test/postoffice_web/controllers/api/bulk_message_controller_test.exs
@@ -20,6 +20,16 @@ defmodule PostofficeWeb.Api.BulkMessageControllerTest do
     topic: "test"
   }
 
+  @exceed_max_ingestion_messages_attrs %{
+    attributes: %{},
+    payload: [
+      %{"key" => "test", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]},
+      %{"key" => "test", "key_list" => [%{"letter" => "c"}, %{"letter" => "d"}]},
+      %{"key" => "test", "key_list" => [%{"letter" => "e"}, %{"letter" => "f"}]}
+    ],
+    topic: "test"
+  }
+
   setup %{conn: conn} do
     {:ok, topic} = Messaging.create_topic(%{name: "test", origin_host: "example.com"})
     Fixtures.create_publisher(topic)
@@ -38,6 +48,13 @@ defmodule PostofficeWeb.Api.BulkMessageControllerTest do
       conn = post(conn, Routes.api_bulk_message_path(conn, :create), @wrong_topic_create_attrs)
 
       assert json_response(conn, 406)
+    end
+
+    test "returns error when ingest more messages than max_bulk_messages", %{conn: conn} do
+      conn = post(conn, Routes.api_bulk_message_path(conn, :create), @exceed_max_ingestion_messages_attrs)
+
+      assert json_response(conn, 406)
+      assert Kernel.length(Messaging.list_messages()) == 0
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -22,3 +22,9 @@ Application.put_env(
   :rescuer_client,
   Postoffice.Rescuer.Adapters.HttpMock
 )
+
+Application.put_env(
+  :postoffice,
+  :max_bulk_messages,
+  3
+)


### PR DESCRIPTION
- Limit message bulk ingest to evict shutdown the node or produce timeout
- Add environment variable to set the max consume messages in bulk