### PR TITLE
Limit message bulk ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ To start your Phoenix server:
   * Create the following environmet variables in order to start the application:
     * `GOOGLE_APPLICATION_CREDENTIALS` with the absolute path to the pubsub credentials file. We provide `config/dummy-credentials.json` to be able to start the app.
     * `GCLOUD_PUBSUB_PROJECT_ID` with the project_id used.
+    * `MAX_BULK_MESSAGES` with the max number of messages that postoffice is able to consume
   * `mix local.hex`
   * `mix archive.install hex phx_new 1.4.11`
   * Install dependencies with `mix deps.get`

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -4,6 +4,7 @@ config :postoffice, PostofficeWeb.Endpoint,
   secret_key_base: {:system, "SECRET_KEY_BASE", default: "12121212"}
 
 config :postoffice, pubsub_project_name: {:system, "GCLOUD_PUBSUB_PROJECT_ID", default: "test"}
+config :postoffice, max_bulk_messages: {:system, "MAX_BULK_MESSAGES", default: 3000}
 
 config :postoffice, Postoffice.Repo,
   username: {:system, "DB_USERNAME", default: "postgres"},

--- a/lib/postoffice.ex
+++ b/lib/postoffice.ex
@@ -61,4 +61,19 @@ defmodule Postoffice do
   end
 
   def ping, do: Application.ensure_started(:postoffice)
+
+  def add_messages_to_deliver(messages) do
+    messages_number = Enum.count(messages["payload"])
+    case messages_number <= get_bulk_messages_limit() do
+      false ->
+        {:error, "Exceed max messages to ingest in bulk"}
+      true ->
+        Messaging.add_messages_to_deliver(messages)
+    end
+  end
+
+  defp get_bulk_messages_limit do
+    Application.get_env(:postoffice, :max_bulk_messages, 3000)
+  end
+
 end

--- a/lib/postoffice/messaging.ex
+++ b/lib/postoffice/messaging.ex
@@ -53,27 +53,16 @@ defmodule Postoffice.Messaging do
   end
 
   def add_messages_to_deliver(%{"topic" => topic} = params) do
-    messages_number = Enum.count(params["payload"])
-    case messages_number <= get_bulk_messages_limit() do
-      false ->
-        {:error, "Exceed max messages to ingest in bulk"}
-
-      true ->
-        case get_topic(topic) |> Repo.preload(:consumers) do
-          nil ->
-            {:error, "Topic does not exist"}
-          topic ->
-            Enum.map(topic.consumers, fn consumer ->
-              generate_jobs_for_messages(consumer, params)
-            end)
-            |> Enum.flat_map(fn elem -> elem end)
-            |> insert_job_changesets()
-        end
+    case get_topic(topic) |> Repo.preload(:consumers) do
+      nil ->
+        {:error, "Topic does not exist"}
+      topic ->
+        Enum.map(topic.consumers, fn consumer ->
+          generate_jobs_for_messages(consumer, params)
+        end)
+        |> Enum.flat_map(fn elem -> elem end)
+        |> insert_job_changesets()
     end
-  end
-
-  defp get_bulk_messages_limit do
-    Application.get_env(:postoffice, :max_bulk_messages, 3000)
   end
 
   def schedule_message(

--- a/lib/postoffice/messaging.ex
+++ b/lib/postoffice/messaging.ex
@@ -54,7 +54,7 @@ defmodule Postoffice.Messaging do
 
   def add_messages_to_deliver(%{"topic" => topic} = params) do
     messages_number = Enum.count(params["payload"])
-    case messages_number <= get_bulk_messages_limit do
+    case messages_number <= get_bulk_messages_limit() do
       false ->
         {:error, "Exceed max messages to ingest in bulk"}
 

--- a/lib/postoffice_web/controllers/api/bulk_message_controller.ex
+++ b/lib/postoffice_web/controllers/api/bulk_message_controller.ex
@@ -3,10 +3,10 @@ defmodule PostofficeWeb.Api.BulkMessageController do
 
   action_fallback PostofficeWeb.Api.FallbackController
 
-  alias Postoffice.Messaging
+  alias Postoffice
 
   def create(conn, message_params) do
-    case Messaging.add_messages_to_deliver(message_params) do
+    case Postoffice.add_messages_to_deliver(message_params) do
       {:ok, ids} ->
         conn
         |> put_status(:created)

--- a/lib/postoffice_web/controllers/api/bulk_message_controller.ex
+++ b/lib/postoffice_web/controllers/api/bulk_message_controller.ex
@@ -12,10 +12,10 @@ defmodule PostofficeWeb.Api.BulkMessageController do
         |> put_status(:created)
         |> render("show.json", message_ids: ids)
 
-      {:error, _reason} ->
+      {:error, reason} ->
         conn
         |> put_status(:not_acceptable)
-        |> render("error.json", error: "Not all messages were inserted")
+        |> render("error.json", error: reason)
     end
   end
 end

--- a/test/postoffice_web/controllers/api/bulk_message_controller_test.exs
+++ b/test/postoffice_web/controllers/api/bulk_message_controller_test.exs
@@ -20,6 +20,17 @@ defmodule PostofficeWeb.Api.BulkMessageControllerTest do
     topic: "test"
   }
 
+  @exceed_max_ingestion_messages_attrs %{
+    attributes: %{},
+    payload: [
+      %{"key" => "test", "key_list" => [%{"letter" => "a"}, %{"letter" => "b"}]},
+      %{"key" => "test", "key_list" => [%{"letter" => "c"}, %{"letter" => "d"}]},
+      %{"key" => "test", "key_list" => [%{"letter" => "e"}, %{"letter" => "f"}]},
+      %{"key" => "test", "key_list" => [%{"letter" => "g"}, %{"letter" => "h"}]}
+    ],
+    topic: "test"
+  }
+
   setup %{conn: conn} do
     {:ok, topic} = Messaging.create_topic(%{name: "test", origin_host: "example.com"})
     Fixtures.create_publisher(topic)
@@ -38,6 +49,13 @@ defmodule PostofficeWeb.Api.BulkMessageControllerTest do
       conn = post(conn, Routes.api_bulk_message_path(conn, :create), @wrong_topic_create_attrs)
 
       assert json_response(conn, 406)
+    end
+
+    test "returns error when ingest more messages than max_bulk_messages", %{conn: conn} do
+      conn = post(conn, Routes.api_bulk_message_path(conn, :create), @exceed_max_ingestion_messages_attrs)
+
+      assert json_response(conn, 406)
+      assert Kernel.length(all_enqueued(queue: :http)) == 0
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -22,3 +22,9 @@ Application.put_env(
   :rescuer_client,
   Postoffice.Rescuer.Adapters.HttpMock
 )
+
+Application.put_env(
+  :postoffice,
+  :max_bulk_messages,
+  3
+)


### PR DESCRIPTION
- Limit message bulk ingest to evict shutdown the node or produce timeout
- Add environment variable to set the max consume messages in bulk